### PR TITLE
Update aerospike-client-c.sh

### DIFF
--- a/scripts/aerospike-client-c.sh
+++ b/scripts/aerospike-client-c.sh
@@ -51,7 +51,7 @@ detect_linux()
 
     case ${DIST_NAME} in
 
-      "centos6" | "redhatenterpriceserver6" )
+      "centos6" | "redhatenterpriceserver6" | "fedora20")
         echo "el6" "rpm"
         return 0
         ;;


### PR DESCRIPTION
on Fedora 20 with LSB installed the scripts throws the error "error: fedora20 is not supported." Without LSB it would have continued successfully.
Modified line 54.
