### PR TITLE
Changed lua_aliases order

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,7 @@ elif LINUX:
       '/lib',
       ]
 
-    lua_aliases = ['lua','lua5.1','lua-5.1']
+    lua_aliases = ['lua5.1','lua-5.1','lua']
 
     liblua = None
     for directory in lua_dirs:


### PR DESCRIPTION
In systems where both liblua-5.1 and liblua-5.2 are installed, it directly links the 5.1 version, without modifying the "global" symbolic link liblua.
