### PR TITLE
Add support to Scientific Linux 6.x

### DIFF
--- a/scripts/aerospike-client-c.sh
+++ b/scripts/aerospike-client-c.sh
@@ -51,7 +51,7 @@ detect_linux()
 
     case ${DIST_NAME} in
 
-      "centos6" | "centos7" | "redhatenterpriceserver6" | "fedora20" | "fedora21" | "oracleserver6" )
+      "centos6" | "centos7" | "redhatenterpriceserver6" | "fedora20" | "fedora21" | "oracleserver6" | "scientific6" )
         echo "el6" "rpm"
         return 0
         ;;
@@ -106,7 +106,7 @@ detect_linux()
     dist=$(cat /etc/issue | tr '[:upper:]' '[:lower:]')
     case ${dist} in
 
-      "centos"* | "red hat enterprise linux"* | "fedora"* | "oracleserver"* )
+      "centos"* | "red hat enterprise linux"* | "fedora"* | "oracleserver"* | "scientific linux"* )
         echo "el6" "rpm"
         return 0
         ;;


### PR DESCRIPTION
``pip instlal aerospike`` when error on Scientific Linux 6.

without LSB:
```
info: Executing ./scripts/aerospike-client-c.sh
which: no lsb_release in (/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin)
error:  is not supported.
error: scripts/aerospike-client-c.sh 1
```

with LSB:
```
info: Executing ./scripts/aerospike-client-c.sh
error: scientific6 is not supported.
error: scripts/aerospike-client-c.sh 1
```