### PR TITLE
Convert Python's None to AS equivalent [Fixes #63]

### DIFF
--- a/src/main/conversions.c
+++ b/src/main/conversions.c
@@ -397,6 +397,9 @@ as_status pyobject_to_val(as_error * err, PyObject * py_obj, as_val ** val, as_s
 		if ( err->code == AEROSPIKE_OK ) {
 			*val = (as_val *) map;
 		}
+	}
+	else if ( Py_None == py_obj ) {
+		*val = as_val_reserve(&as_nil);
 	} else {
 		as_bytes *bytes;
 		GET_BYTES_POOL(bytes, static_pool, err);

--- a/test/test_apply.py
+++ b/test/test_apply.py
@@ -95,6 +95,18 @@ class TestApply(TestBaseClass):
         assert bins['name'] == ['name1', 'car']
         assert retval == 0
 
+    def test_apply_with_none_parameter(self):
+        """
+            Invoke apply() with a None argument
+        """
+        key = ('test', 'demo', 1)
+        retval = TestApply.client.apply(key, 'sample', 'list_append', ['name',
+                                                                       None])
+        (key, meta, bins) = TestApply.client.get(key)
+
+        assert bins['name'] == ['name1', None]
+        assert retval == 0
+
     def test_apply_with_policy(self):
         """
             Invoke apply() with policy


### PR DESCRIPTION
When I run the test mentioned in #63, I get the following output:

    $ python test_apply.py
    First iteration
    (('test', 'demo', None, bytearray(b'\xf5~\xc1\x835\xf7\x10\x0c\x04X\xf8\xa6D\xbc\xbcvm\x93G\x1e')), {'gen': 45, 'ttl': 4294967295}, {'param2': 'baz', 'param1': 20})
    Second iteration
    (('test', 'demo', None, bytearray(b'\xf5~\xc1\x835\xf7\x10\x0c\x04X\xf8\xa6D\xbc\xbcvm\x93G\x1e')), {'gen': 46, 'ttl': 4294967295}, {'param1': 30})

Aerospike log:

    Jun 26 2015 22:52:13 GMT: WARNING (udf): ([C]::-1) Parameters: 20, baz
    Jun 26 2015 22:52:13 GMT: WARNING (udf): ([C]::-1) Parameters: 30, nil