### PR TITLE
fixed scan issue - false ParamError when set not provided

### DIFF
--- a/src/main/scan/type.c
+++ b/src/main/scan/type.c
@@ -94,9 +94,7 @@ static int AerospikeScan_Type_Init(AerospikeScan * self, PyObject * args, PyObje
 		} else if ( Py_None == py_set ) {
 			set = NULL;
 		}
-	} else {
-		return -1;
-	}
+	} else
 
 	as_scan_init(&self->scan, namespace, set);
 

--- a/src/main/scan/type.c
+++ b/src/main/scan/type.c
@@ -94,7 +94,9 @@ static int AerospikeScan_Type_Init(AerospikeScan * self, PyObject * args, PyObje
 		} else if ( Py_None == py_set ) {
 			set = NULL;
 		}
-	} else
+	} else {
+                set = NULL;
+        }
 
 	as_scan_init(&self->scan, namespace, set);
 


### PR DESCRIPTION
Fixes issue which caused ParamError when `set` param wasn't provided to Scan init.
Now it behaves as described in [documentation](https://pythonhosted.org/aerospike/client.html#aerospike.Client.scan)

```python
Traceback (most recent call last):
  File "scan.py", line 41, in <module>
    scan = a.scan('test') # 'test')
exception.ParamError: (-2L, 'Parameters are incorrect', 'src/main/scan/type.c', 186)
```