### PR TITLE
Mis-spelling of redhat server

### DIFF
--- a/scripts/aerospike-client-c.sh
+++ b/scripts/aerospike-client-c.sh
@@ -53,7 +53,7 @@ detect_linux()
 
     case ${DIST_NAME} in
 
-      "centos6" | "centos7" | "redhatenterpriceserver6" | "fedora20" | "fedora21" | "fedora22" | "oracleserver6" | "scientific6" )
+      "centos6" | "centos7" | "redhatenterpriseserver6" | "fedora20" | "fedora21" | "fedora22" | "oracleserver6" | "scientific6" )
         echo "el6" "rpm"
         return 0
         ;;


### PR DESCRIPTION
Changed redhatenterpriceserver6 to redhatenterpriseserver6