### PR TITLE
Tweak the implementation of scan_apply to match the python client's d…

### DIFF
--- a/src/main/client/scan.c
+++ b/src/main/client/scan.c
@@ -105,7 +105,7 @@ PyObject * AerospikeClient_ScanApply_Invoke(
 		goto CLEANUP;
 	}
 
-	if (!PyList_Check(py_args)) {
+	if (py_args && !PyList_Check(py_args)) {
 		as_error_update(&err, AEROSPIKE_ERR_PARAM, "Arguments should be a list");
 		goto CLEANUP;
 	}
@@ -164,10 +164,12 @@ PyObject * AerospikeClient_ScanApply_Invoke(
 		goto CLEANUP;
 	}
 
-	pyobject_to_list(self, &err, py_args, &arglist, &static_pool,
+	if (py_args) {
+		pyobject_to_list(self, &err, py_args, &arglist, &static_pool,
 			SERIALIZER_PYTHON);
-	if (err.code != AEROSPIKE_OK) {
-		goto CLEANUP;
+		if (err.code != AEROSPIKE_OK) {
+			goto CLEANUP;
+		}
 	}
 
 	if (!as_scan_apply_each(&scan, module_p, function_p, arglist)) {


### PR DESCRIPTION
…ocumentation, wherein providing additional args to a UDF is optional.

Ref: [Documentation for Client.scan_apply](http://www.aerospike.com/apidocs/python/client.html?highlight=scan_apply#aerospike.Client.scan_apply)

In the current implementation, passing no py_args into the Client.scan_apply() function results in a segfault, which is no bueno.

If the ability to pass no py_args is *not* the desired behavior, then I believe that the documentation should be changed, and line 103 modified to also ensure that py_args is present and return a useful error:
```
if (!(namespace_p) || !(py_set) || !(py_module) || !(py_function) || !(py_args)) {
    as_error_update(&err, AEROSPIKE_ERR_PARAM, "Parameter should not be null");
    goto CLEANUP;
}
```
