### PR TITLE
Allow installation on Ubuntu 16.04+

### DIFF
--- a/scripts/aerospike-client-c.sh
+++ b/scripts/aerospike-client-c.sh
@@ -68,7 +68,7 @@ detect_linux()
         return 0
         ;;
 
-      "ubuntu12" | "ubuntu13" | "ubuntu14" | "ubuntu15" | "linuxmint17" )
+      "ubuntu12" | "ubuntu13" | "ubuntu14" | "ubuntu15" | "ubuntu16" | "linuxmint17" )
         echo "ubuntu12"  "deb"
         return 0
         ;;
@@ -146,7 +146,7 @@ detect_linux()
       "ubuntu"* )
         vers=$(lsb_release -r -s)
         case ${vers} in
-          "12."* | "13."* | "14."* | "15."* )
+          "12."* | "13."* | "14."* | "15."* | "16."* )
             echo "ubuntu12"  "deb"
             return 0
             ;;


### PR DESCRIPTION
See https://github.com/aerospike/aerospike-client-python/issues/121
