### PR TITLE
Ensure environment variables to be passed to scripts/aerospike-client…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ from distutils.command.build import build
 from setuptools.command.install import install
 from setuptools import setup, Extension
 from shutil import copytree, copy2
-from subprocess import call
+from subprocess import Popen
 
 
 class InstallCommand(install):
@@ -100,7 +100,9 @@ def resolve_c_client(lua_src_path, lua_system_path):
 
     print('info: Executing','./scripts/aerospike-client-c.sh', file=sys.stdout)
     os.chmod('./scripts/aerospike-client-c.sh',0o0755)
-    rc = call(['./scripts/aerospike-client-c.sh'])
+    p = Popen(['./scripts/aerospike-client-c.sh'], env=os.environ)
+    rc = p.wait()
+
     if rc != 0 :
         print("error: scripts/aerospike-client-c.sh", rc, file=sys.stderr)
         sys.exit(1)


### PR DESCRIPTION
…-c.sh

While behind a proxy, the installation of the aerospike module with
`pip install aerospike` was not working because the `https_proxy`
and/or `http_proxy` environment variables were not pass through.

It now passes ALL environment variables.