### PR TITLE
Remove ldt setting in travis environment

### DIFF
--- a/.travis/aerospike.conf
+++ b/.travis/aerospike.conf
@@ -51,7 +51,6 @@ network {
 namespace test {
   replication-factor 2
   memory-size 1G
-  ldt-enabled true
   default-ttl 30d # 30 days, use 0 to never expire/evict.
   storage-engine memory
 }


### PR DESCRIPTION
Allows CI to launch server when running against server versions >= 3.15.0.1