### PR TITLE
Fix os_version for right definition of RHEL

### DIFF
--- a/scripts/os_version
+++ b/scripts/os_version
@@ -57,7 +57,7 @@ main() {
 		*'centos'* )
 			distro_id='centos'
 			;;
-		*'redhat'* )
+		*'red hat'* )
 			distro_id='redhat'
 			;;
 		*'debian'* )


### PR DESCRIPTION
The content of my '/etc/issue' is 
```
Red Hat Enterprise Linux Server release 6.2 (Santiago)
Kernel \r on an \m
```
Need add space into `os_version` for right definition of RHEL.
Another example https://www.cyberciti.biz/faq/what-version-of-redhat-linux-am-i-running/