### PR TITLE
fail on 4XX response codes

### DIFF
--- a/scripts/aerospike-client-c.sh
+++ b/scripts/aerospike-client-c.sh
@@ -52,7 +52,7 @@ download() {
   printf "info: downloading '%s' to '%s'\n" "${url}" "${dest}"
 
   if has_cmd curl; then
-    curl -L ${url} > ${dest}
+    curl -f -L ${url} --output ${dest}
     if [ $? != 0 ]; then
       echo "error: Unable to download package from '${url}'"
       exit 1


### PR DESCRIPTION
https://curl.haxx.se/mail/archive-2006-02/0004.html the exit status of
curl on a 4XX response code is zero without the -f flag.

curl is redirecting through the artifact link and then downloading the 404 page as a `.deb` which the script attempts to install. This change enables a non-zero return code from curl as intended.