### PR TITLE
Fix installation in Python 3.8.1 on Mac OS X 10.15.2 (#250)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ AEROSPIKE_C_HOME = os.getenv('AEROSPIKE_C_HOME')
 PREFIX = None
 PLATFORM = platform.platform(1)
 LINUX = 'Linux' in PLATFORM
-DARWIN = 'Darwin' in PLATFORM
+DARWIN = 'Darwin' in PLATFORM or 'macOS' in PLATFORM
 CWD = os.path.abspath(os.path.dirname(__file__))
 
 ################################################################################


### PR DESCRIPTION
A quick-n-dirty fix for installation on Mac OS X 10.15.2 using Python 3.8.1.