### PR TITLE
Fix syntax error in truncate.c

### DIFF
--- a/src/main/client/truncate.c
+++ b/src/main/client/truncate.c
@@ -130,7 +130,7 @@ AerospikeClient_Truncate(AerospikeClient * self, PyObject * args, PyObject * kwd
 	}
 
 	// Start conversion of the nanosecond parameter
-	if PyLong_Check(py_nanos) {
+	if (PyLong_Check(py_nanos)) {
 
 		temp_long = PyLong_AsLongLong(py_nanos);
 		// There was a negative number outside of the range of - 2 ^ 63
@@ -147,7 +147,7 @@ AerospikeClient_Truncate(AerospikeClient * self, PyObject * args, PyObject * kwd
 			goto CLEANUP;
 		}
 
-	} else if PyInt_Check(py_nanos) {
+	} else if (PyInt_Check(py_nanos)) {
 		long tempInt;
 		tempInt = PyInt_AsLong(py_nanos);
 


### PR DESCRIPTION
Fix syntax error in truncate.c causing the below exception:

      src/main/client/truncate.c:133:5: error: expected '(' after 'if'
              if PyLong_Check(py_nanos) {
                 ^