### PR TITLE
Add requirements.txt for readthedocs.org

### DIFF
--- a/doc/client.rst
+++ b/doc/client.rst
@@ -2370,7 +2370,7 @@ Info Operations
 
         .. versionchanged:: 5.0.0
 
-        .. warning:: for client versions < 3.0.0 ``set_xdr_filter`` will not work when using TLS.
+        .. warning:: Requires Aerospike server version >= 5.3.
 
     .. method:: shm_key()  ->  int
 
@@ -2821,7 +2821,7 @@ Write Policies
             |
             | Default: ``False``
 
-            .. note:: Requires Enterprise server version >= 5.0
+            .. note:: Requires Aerospike server version >= 5.2.
         * **expressions** :class:`list`
             | Compiled aerospike expressions :mod:`aerospike_helpers` used for filtering records within a transaction.
             |
@@ -2901,7 +2901,7 @@ Read Policies
             |
             | Default: ``aerospike.POLICY_REPLICA_SEQUENCE``
 
-            .. note:: Requires Enterprise server version >= 5.0
+            .. note:: Requires Aerospike server version >= 5.2.
         * **expressions** :class:`list`
             | Compiled aerospike expressions :mod:`aerospike_helpers` used for filtering records within a transaction.
             |
@@ -2996,7 +2996,7 @@ Operate Policies
             |
             | Default: ``False``
 
-            .. note:: Requires Enterprise server version >= 5.0
+            .. note:: Requires Aerospike server version >= 5.2.
         * **expressions** :class:`list`
             | Compiled aerospike expressions :mod:`aerospike_helpers` used for filtering records within a transaction.
             |
@@ -3073,7 +3073,7 @@ Apply Policies
             |
             | Default: ``False``
 
-            .. note:: Requires Enterprise server version >= 5.0
+            .. note:: Requires Aerospike server version >= 5.2.
         * **expressions** :class:`list`
             | Compiled aerospike expressions :mod:`aerospike_helpers` used for filtering records within a transaction.
             |
@@ -3153,7 +3153,7 @@ Remove Policies
             | 
             | Default: ``aerospike.POLICY_REPLICA_SEQUENCE``
 
-            .. note:: Requires Enterprise server version >= 5.0
+            .. note:: Requires Aerospike server version >= 5.2.
         * **expressions** :class:`list`
             | Compiled aerospike expressions :mod:`aerospike_helpers` used for filtering records within a transaction.
             |

--- a/doc/client.rst
+++ b/doc/client.rst
@@ -2820,12 +2820,12 @@ Write Policies
             | Perform durable delete
             |
             | Default: ``False``
-
-            .. note:: Requires Aerospike server version >= 5.2.
         * **expressions** :class:`list`
             | Compiled aerospike expressions :mod:`aerospike_helpers` used for filtering records within a transaction.
             |
             | Default: None
+
+            .. note:: Requires Aerospike server version >= 5.2.
             
 
 .. _aerospike_read_policies:
@@ -2900,12 +2900,12 @@ Read Policies
             | One of the :ref:`POLICY_REPLICA` values such as :data:`aerospike.POLICY_REPLICA_MASTER`
             |
             | Default: ``aerospike.POLICY_REPLICA_SEQUENCE``
-
-            .. note:: Requires Aerospike server version >= 5.2.
         * **expressions** :class:`list`
             | Compiled aerospike expressions :mod:`aerospike_helpers` used for filtering records within a transaction.
             |
             | Default: None
+
+            .. note:: Requires Aerospike server version >= 5.2.
 
 .. _aerospike_operate_policies:
 
@@ -2995,12 +2995,12 @@ Operate Policies
             | Perform durable delete
             |
             | Default: ``False``
-
-            .. note:: Requires Aerospike server version >= 5.2.
         * **expressions** :class:`list`
             | Compiled aerospike expressions :mod:`aerospike_helpers` used for filtering records within a transaction.
             |
             | Default: None
+
+            .. note:: Requires Aerospike server version >= 5.2.
 
 .. _aerospike_apply_policies:
 
@@ -3072,12 +3072,12 @@ Apply Policies
             | Perform durable delete
             |
             | Default: ``False``
-
-            .. note:: Requires Aerospike server version >= 5.2.
         * **expressions** :class:`list`
             | Compiled aerospike expressions :mod:`aerospike_helpers` used for filtering records within a transaction.
             |
             | Default: None
+            
+            .. note:: Requires Aerospike server version >= 5.2.
 
 
 .. _aerospike_remove_policies:
@@ -3153,11 +3153,12 @@ Remove Policies
             | 
             | Default: ``aerospike.POLICY_REPLICA_SEQUENCE``
 
-            .. note:: Requires Aerospike server version >= 5.2.
         * **expressions** :class:`list`
             | Compiled aerospike expressions :mod:`aerospike_helpers` used for filtering records within a transaction.
             |
             | Default: None
+
+            .. note:: Requires Aerospike server version >= 5.2.
 
 .. _aerospike_batch_policies:
 

--- a/doc/query.rst
+++ b/doc/query.rst
@@ -558,12 +558,12 @@ Query Policies
             | Terminate query if cluster is in migration state. 
             |
             | Default ``False``
-
-            .. note:: Requires Aerospike server version >= 5.2.
         * **expressions** :class:`list`
             | Compiled aerospike expressions :mod:`aerospike_helpers` used for filtering records within a transaction.
             |
             | Default: None
+
+            .. note:: Requires Aerospike server version >= 5.2.
 
 .. _aerospike_query_options:
 

--- a/doc/query.rst
+++ b/doc/query.rst
@@ -559,7 +559,7 @@ Query Policies
             |
             | Default ``False``
 
-            .. note:: Requires Enterprise server version >= 5.0
+            .. note:: Requires Aerospike server version >= 5.2.
         * **expressions** :class:`list`
             | Compiled aerospike expressions :mod:`aerospike_helpers` used for filtering records within a transaction.
             |

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,0 +1,2 @@
+# sphinx version requirement for readthedocs.
+sphinx>=3.2.1

--- a/doc/scan.rst
+++ b/doc/scan.rst
@@ -414,7 +414,7 @@ Scan Policies
             |
             | Default: ``0`` (no limit).
 
-            .. note:: Requires Enterprise server version >= 5.0
+            .. note:: Requires Aerospike server version >= 5.2.
         * **expressions** :class:`list`
             | Compiled aerospike expressions :mod:`aerospike_helpers` used for filtering records within a transaction.
             |

--- a/doc/scan.rst
+++ b/doc/scan.rst
@@ -413,12 +413,12 @@ Scan Policies
             | Requires server version >= 4.7.0.
             |
             | Default: ``0`` (no limit).
-
-            .. note:: Requires Aerospike server version >= 5.2.
         * **expressions** :class:`list`
             | Compiled aerospike expressions :mod:`aerospike_helpers` used for filtering records within a transaction.
             |
             | Default: ``None``
+
+            .. note:: Requires Aerospike server version >= 5.2.
             
 
 .. _aerospike_scan_options:


### PR DESCRIPTION
Add a requirements file to the docs directory instructing readthedocs.org to build the docs with a specific sphinx version. Also adjust some 5.0.0 Aerospike expressions related documentation.