### PR TITLE
Support M1/ARM

### DIFF
--- a/.build.yml
+++ b/.build.yml
@@ -3,6 +3,7 @@ name: aerospike-client-python
 container:
   - base:
       - docker.qe.aerospike.com/build/aerospike-client-python:manylinux2014
+      - docker.qe.aerospike.com/build/aerospike-client-python:arm-manylinux2014
 
 build:
   - name: build

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,4 +2,4 @@
 	path = aerospike-client-c
 	# url = git@github.com:aerospike/aerospike-client-c.git
 	url = https://github.com/aerospike/aerospike-client-c.git
-	branch = m1
+	branch = stage

--- a/src/main/client/bit_operate.c
+++ b/src/main/client/bit_operate.c
@@ -905,20 +905,21 @@ static as_status get_bit_policy(as_error *err, PyObject *op_dict,
 static as_status get_bool_from_pyargs(as_error *err, char *key,
                                       PyObject *op_dict, bool *boolean)
 {
-	PyObject *py_val = PyDict_GetItemString(op_dict, key);
-	if (!py_val) {
-		// op_dict does not contain key
-		return as_error_update(err, AEROSPIKE_ERR_PARAM, "Failed to convert %s",
-							   key);
-	}
+    PyObject *py_val = PyDict_GetItemString(op_dict, key);
+    if (!py_val) {
+        // op_dict does not contain key
+        return as_error_update(err, AEROSPIKE_ERR_PARAM, "Failed to convert %s",
+                               key);
+    }
 
-	if (!PyBool_Check(py_val)) {
-		return as_error_update(err, AEROSPIKE_ERR_PARAM,
-								"key %s does not point to a boolean in the dict", key);
-	}
+    if (!PyBool_Check(py_val)) {
+        return as_error_update(err, AEROSPIKE_ERR_PARAM,
+                               "key %s does not point to a boolean in the dict",
+                               key);
+    }
 
-	*boolean = (bool)PyObject_IsTrue(py_val);
-	return AEROSPIKE_OK;
+    *boolean = (bool)PyObject_IsTrue(py_val);
+    return AEROSPIKE_OK;
 }
 
 static as_status get_uint8t_from_pyargs(as_error *err, char *key,

--- a/src/main/client/bit_operate.c
+++ b/src/main/client/bit_operate.c
@@ -905,21 +905,20 @@ static as_status get_bit_policy(as_error *err, PyObject *op_dict,
 static as_status get_bool_from_pyargs(as_error *err, char *key,
                                       PyObject *op_dict, bool *boolean)
 {
-    PyObject *py_val = PyDict_GetItemString(op_dict, key);
+	PyObject *py_val = PyDict_GetItemString(op_dict, key);
+	if (!py_val) {
+		// op_dict does not contain key
+		return as_error_update(err, AEROSPIKE_ERR_PARAM, "Failed to convert %s",
+							   key);
+	}
 
-    if (!py_val) {
-        return as_error_update(err, AEROSPIKE_ERR_PARAM, "Failed to convert %s",
-                               key);
-    }
+	if (!PyBool_Check(py_val)) {
+		return as_error_update(err, AEROSPIKE_ERR_PARAM,
+								"key %s does not point to a boolean in the dict", key);
+	}
 
-    if (PyBool_Check(py_val)) {
-        if (get_int64_t(err, key, op_dict, ((int64_t *)(boolean))) !=
-            AEROSPIKE_OK) {
-            return err->code;
-        }
-    }
-
-    return AEROSPIKE_OK;
+	*boolean = (bool)PyObject_IsTrue(py_val);
+	return AEROSPIKE_OK;
 }
 
 static as_status get_uint8t_from_pyargs(as_error *err, char *key,


### PR DESCRIPTION
All test cases pass on M1 using Kubelab to run the Aerospike server and the C client on commit [84cfce3](https://github.com/aerospike/aerospike-client-c/commit/84cfce3dda7216b05b39b0be437b570e30b2f06f).

We need to change the C client submodule to point to the master branch before merging.