### PR TITLE
[CLIENT-1962] Split up github actions test workflow into multiple jobs

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,6 @@
+[flake8]
+max-line-length = 120
+extend-ignore = E203
+filename =
+    ./aerospike_helpers/**/*.py,
+    ./test/**/*.py

--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,6 @@
 [flake8]
 max-line-length = 120
+# For black compatibility:
 extend-ignore = E203
 filename =
     ./aerospike_helpers/**/*.py,

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
         check-path: 'src'
         clang-format-version: 14
 
-  build-and-install:
+  build-install-test:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -53,14 +53,15 @@ jobs:
     - name: Build client
       run: python3 -m build
 
-    - name: Check installing the client
+    - name: Install client
       run: pip install .
 
-    - name: Cache build artifacts
-      uses: actions/cache@v3
-      with:
-        # Build distributions location
-        path: dist/
+    - name: Install test dependencies
+      run: pip install -r test/requirements.txt
+
+    - name: Run tests
+      run: python -m pytest ./new_tests
+      working-directory: test
 
   build-docs:
     runs-on: ubuntu-latest
@@ -94,25 +95,5 @@ jobs:
       # TODO: find way to split up dependencies
       run: python -m pip install -r doc/requirements.txt
     - name: Check spelling
-      run: |
-        cd doc/
-        sphinx-build -b spelling . spelling -W --keep-going
-
-  tests:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: recursive
-    - name: Set up Aerospike Database
-      uses: reugn/github-action-aerospike@dev
-      with:
-        port: 3000
-    - uses: actions/setup-python@v2
-      with:
-        python-version: '3.9'
-        architecture: 'x64'
-    - name: Run tests
-      run: |
-        cd test/
-        python -m pytest ./new_tests
+      run: sphinx-build -b spelling . spelling -W --keep-going
+      working-directory: doc

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -97,8 +97,7 @@ jobs:
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./htmldir
-      working-directory: doc
+        publish_dir: ./doc/htmldir
 
   spellcheck-docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,6 +62,15 @@ jobs:
     - name: Install test dependencies
       run: pip install -r test/requirements.txt
 
+    - name: Set up Aerospike Database
+      uses: reugn/github-action-aerospike@dev
+      with:
+        port: 3000
+
+    - name: Wait for database to be ready
+      # Should be ready after 3 seconds
+      run: sleep 3
+
     - name: Run tests
       run: python -m pytest ./new_tests
       working-directory: test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -98,26 +98,21 @@ jobs:
         cd doc/
         sphinx-build -b spelling . spelling -W --keep-going
 
-  # tests:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - uses: actions/checkout@v2
-  #     with:
-  #       submodules: recursive
-  #   - name: Set up Aerospike Database
-  #     uses: reugn/github-action-aerospike@dev
-  #     with:
-  #       port: 3000
-  #   - uses: actions/setup-python@v2
-  #     with:
-  #       python-version: '3.9'
-  #       architecture: 'x64'
-  #   - name: Build documentation
-  #     run: |
-  #       cd doc/
-  #       sphinx-build -b spelling . spelling -W --keep-going
-  #       sphinx-build -b html . htmldir -W
-  #   - name: Run tests
-  #     run: |
-  #       cd test
-  #       python -m pytest ./new_tests
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: Set up Aerospike Database
+      uses: reugn/github-action-aerospike@dev
+      with:
+        port: 3000
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
+        architecture: 'x64'
+    - name: Run tests
+      run: |
+        cd test/
+        python -m pytest ./new_tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,48 +9,115 @@ on:
   pull_request:
     branches: ["stage"]
   workflow_dispatch:
+
 jobs:
-  tests:
+  lint:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
       with:
         submodules: recursive
-    - name: Set up Aerospike Database
-      uses: reugn/github-action-aerospike@dev
-      with:
-        port: 3000
     - uses: actions/setup-python@v2
       with:
         python-version: '3.9'
         architecture: 'x64'
-    - name: Install development dependencies
-      run: |
-        sudo apt-get install libssl-dev
-        sudo apt-get install python3-dev
-        python -m pip install -r doc/requirements.txt -r test/requirements.txt flake8
+    - name: Install linting dependencies
+      run: python -m pip install flake8
     - name: Lint Python code
-      run: |
-        # Ignore E203 to be compatible with black
-        flake8 --max-line-length=120 --count --extend-ignore=E203 aerospike_helpers/ test/
-    - name: clang-format Check
+      # Ignore E203 to be compatible with black
+      run: flake8 --max-line-length=120 --count --extend-ignore=E203 aerospike_helpers/ test/
+    - name: Lint C wrapper code
       uses: jidicula/clang-format-action@v4.9.0
       with:
         check-path: 'src'
         clang-format-version: 14
-    - name: Build documentation
+
+  build-and-install:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
+        architecture: 'x64'
+
+    - run: sudo apt update
+    - name: Install build dependencies (apt packages)
+      run: sudo apt install python3-dev libssl-dev -y
+    - name: Install build dependencies (pip packages)
+      run: python3 -m pip install build
+
+    - name: Build client
+      run: python3 -m build
+
+    - name: Check installing the client
+      run: pip install .
+
+    - name: Cache build artifacts
+      uses: actions/cache@v3
+      with:
+        # Build distributions location
+        path: dist/
+
+  build-docs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
+        architecture: 'x64'
+    - name: Install dependencies for building docs
+      # TODO: find way to split up dependencies
+      run: python -m pip install -r doc/requirements.txt
+    - name: Build docs
+      run: |
+        cd doc/
+        sphinx-build -b html . htmldir/
+
+  spellcheck-docs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
+        architecture: 'x64'
+    - name: Install dependencies for checking spelling in docs
+      # TODO: find way to split up dependencies
+      run: python -m pip install -r doc/requirements.txt
+    - name: Check spelling
       run: |
         cd doc/
         sphinx-build -b spelling . spelling -W --keep-going
-        sphinx-build -b html . htmldir -W
-    - name: Build client
-      run: |
-        python3 -m pip install build
-        python3 -m build
-    - name: Install client
-      run: |
-        pip install .
-    - name: Run tests
-      run: |
-        cd test
-        python -m pytest ./new_tests
+
+  # tests:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #     with:
+  #       submodules: recursive
+  #   - name: Set up Aerospike Database
+  #     uses: reugn/github-action-aerospike@dev
+  #     with:
+  #       port: 3000
+  #   - uses: actions/setup-python@v2
+  #     with:
+  #       python-version: '3.9'
+  #       architecture: 'x64'
+  #   - name: Build documentation
+  #     run: |
+  #       cd doc/
+  #       sphinx-build -b spelling . spelling -W --keep-going
+  #       sphinx-build -b html . htmldir -W
+  #   - name: Run tests
+  #     run: |
+  #       cd test
+  #       python -m pytest ./new_tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,6 @@ jobs:
     - name: Install linting dependencies
       run: python -m pip install flake8
     - name: Lint Python code
-      # Ignore E203 to be compatible with black
       run: python -m flake8
     - name: Lint C wrapper code
       uses: jidicula/clang-format-action@v4.9.0
@@ -74,29 +73,6 @@ jobs:
     - name: Run tests
       run: python -m pytest ./new_tests
       working-directory: test
-
-  build-and-preview-docs:
-    permissions:
-      pull-requests: write
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: recursive
-    - uses: actions/setup-python@v2
-      with:
-        python-version: '3.9'
-        architecture: 'x64'
-    - name: Install dependencies for building docs
-      # TODO: find way to split up dependencies
-      run: python -m pip install -r doc/requirements.txt
-    - name: Build docs
-      run: python -m sphinx -b html . htmldir/
-      working-directory: doc
-    - name: Deploy preview of docs
-      uses: readthedocs/actions/preview@v1
-      with:
-        project-slug: "aerospike-python-client"
 
   spellcheck-docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,7 +75,7 @@ jobs:
       run: python -m pytest ./new_tests
       working-directory: test
 
-  build-docs:
+  build-and-preview-docs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -89,9 +89,13 @@ jobs:
       # TODO: find way to split up dependencies
       run: python -m pip install -r doc/requirements.txt
     - name: Build docs
-      run: |
-        cd doc/
-        sphinx-build -b html . htmldir/
+      run: sphinx-build -b html . htmldir/
+      working-directory: doc
+    - name: Deploy preview of docs
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./htmldir
 
   spellcheck-docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: Pytest Tests
+name: PR pre-merge tests
 
 # Trigger test workflow whenever:
 # 1. A pull request is updated (e.g with new commits)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,7 +77,7 @@ jobs:
 
   build-and-preview-docs:
     permissions:
-      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -94,10 +94,9 @@ jobs:
       run: python -m sphinx -b html . htmldir/
       working-directory: doc
     - name: Deploy preview of docs
-      uses: peaceiris/actions-gh-pages@v3
+      uses: readthedocs/actions/preview@v1
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./doc/htmldir
+        project-slug: "aerospike-python-client"
 
   spellcheck-docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,6 +34,9 @@ jobs:
 
   build-install-test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        py-version: [3.7, 3.8, 3.9]
     steps:
     - uses: actions/checkout@v2
       with:
@@ -41,7 +44,7 @@ jobs:
 
     - uses: actions/setup-python@v2
       with:
-        python-version: '3.9'
+        python-version: ${{ matrix.py-version }}
         architecture: 'x64'
 
     - run: sudo apt update

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
       run: python -m pip install flake8
     - name: Lint Python code
       # Ignore E203 to be compatible with black
-      run: flake8 --max-line-length=120 --count --extend-ignore=E203 aerospike_helpers/ test/
+      run: python -m flake8
     - name: Lint C wrapper code
       uses: jidicula/clang-format-action@v4.9.0
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,6 +76,8 @@ jobs:
       working-directory: test
 
   build-and-preview-docs:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -89,13 +91,14 @@ jobs:
       # TODO: find way to split up dependencies
       run: python -m pip install -r doc/requirements.txt
     - name: Build docs
-      run: sphinx-build -b html . htmldir/
+      run: python -m sphinx -b html . htmldir/
       working-directory: doc
     - name: Deploy preview of docs
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./htmldir
+      working-directory: doc
 
   spellcheck-docs:
     runs-on: ubuntu-latest

--- a/BUILD.md
+++ b/BUILD.md
@@ -143,7 +143,7 @@ pip install flake8
 
 The command is:
 ```
-flake8 --max-line-length=120 --extend-ignore=E203 aerospike_helpers/
+python3 -m flake8
 ```
 
 All C source code must be formatted with `clang-format`:


### PR DESCRIPTION
- Splits up test workflow job into multiple jobs to get all info in parallel
- Use flake8 config file instead of command line arguments (and update instructions)
- Run build, install, and integration tests on all supported Python versions
- Show preview of ReadTheDocs docs for PRs