### PR TITLE
[CLIENT-2288] aerospike.client(): add client config options "max_error_rate" and "error_rate_window"

### DIFF
--- a/.github/workflows/build-alpine.sh
+++ b/.github/workflows/build-alpine.sh
@@ -3,8 +3,7 @@
 set -e
 set -x
 
-apk add git py3-pip python3-dev zlib-dev automake make musl-dev gcc openssl-dev lua-dev libuv-dev doxygen graphviz
-git clone --branch $2 --recurse-submodules https://github.com/$1/aerospike-client-python
+apk add py3-pip python3-dev zlib-dev automake make musl-dev gcc openssl-dev lua-dev libuv-dev doxygen graphviz
 cd aerospike-client-python/
 
 python3 -m pip install build

--- a/.github/workflows/build-alpine.sh
+++ b/.github/workflows/build-alpine.sh
@@ -4,8 +4,8 @@ set -e
 set -x
 
 apk add py3-pip python3-dev zlib-dev automake make musl-dev gcc openssl-dev lua-dev libuv-dev doxygen graphviz
-cd aerospike-client-python/
 
+# Executed inside the aerospike-client-python directory
 python3 -m pip install build
 python3 -m build
 python3 -m pip install dist/*.whl

--- a/.github/workflows/build-alpine.sh
+++ b/.github/workflows/build-alpine.sh
@@ -4,7 +4,7 @@ set -e
 set -x
 
 apk add git py3-pip python3-dev zlib-dev automake make musl-dev gcc openssl-dev lua-dev libuv-dev doxygen graphviz
-git clone --branch $1 --recurse-submodules https://github.com/aerospike/aerospike-client-python
+git clone --branch $2 --recurse-submodules https://github.com/$1/aerospike-client-python
 cd aerospike-client-python/
 
 python3 -m pip install build

--- a/.github/workflows/build-rhel9.sh
+++ b/.github/workflows/build-rhel9.sh
@@ -7,7 +7,7 @@ set -x
 yum update -y
 yum install -y git openssl-devel glibc-devel autoconf automake libtool zlib-devel openssl-devel python-devel
 
-git clone --branch $1 --recurse-submodules https://github.com/aerospike/aerospike-client-python
+git clone --branch $2 --recurse-submodules https://github.com/$1/aerospike-client-python
 cd aerospike-client-python/
 
 python3 -m pip install build

--- a/.github/workflows/build-rhel9.sh
+++ b/.github/workflows/build-rhel9.sh
@@ -3,13 +3,9 @@
 set -e
 set -x
 
-# Update packages to get latest git version
-yum update -y
-yum install -y git openssl-devel glibc-devel autoconf automake libtool zlib-devel openssl-devel python-devel
-
-git clone --branch $2 --recurse-submodules https://github.com/$1/aerospike-client-python
 cd aerospike-client-python/
 
+yum install -y openssl-devel glibc-devel autoconf automake libtool zlib-devel openssl-devel python-devel
 python3 -m pip install build
 python3 -m build
 python3 -m pip install dist/*.whl

--- a/.github/workflows/build-rhel9.sh
+++ b/.github/workflows/build-rhel9.sh
@@ -3,8 +3,7 @@
 set -e
 set -x
 
-cd aerospike-client-python/
-
+# Executed inside the aerospike-client-python directory
 yum install -y openssl-devel glibc-devel autoconf automake libtool zlib-devel openssl-devel python-devel
 python3 -m pip install build
 python3 -m build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,7 +62,7 @@ jobs:
       run: docker cp . ${{ matrix.distros[1] }}:/aerospike-client-python
 
     - name: Build and test
-      run: docker exec -w /aerospike-client-python ${{ matrix.distros[1] }} ./build-${{ matrix.distros[1] }}.sh
+      run: docker exec -w /aerospike-client-python ${{ matrix.distros[1] }} ./.github/workflows/build-${{ matrix.distros[1] }}.sh
 
     - name: Cleanup
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,7 +62,7 @@ jobs:
       run: docker cp . ${{ matrix.distros[1] }}:/aerospike-client-python
 
     - name: Build and test
-      run: docker exec ${{ matrix.distros[1] }} /aerospike-client-python/build-${{ matrix.distros[1] }}.sh
+      run: docker exec -w /aerospike-client-python ${{ matrix.distros[1] }} ./build-${{ matrix.distros[1] }}.sh
 
     - name: Cleanup
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,7 +67,7 @@ jobs:
       working-directory: .github/workflows
 
     - name: Build and test
-      run: docker exec ${{ matrix.distros[1] }} ./build-${{ matrix.distros[1] }}.sh ${{ env.GITHUB_REF_NAME }}
+      run: docker exec ${{ matrix.distros[1] }} ./build-${{ matrix.distros[1] }}.sh ${{ env.GITHUB_REPOSITORY_OWNER_PART_SLUG_URL }} ${{ env.GITHUB_REF_NAME }}
 
     - name: Cleanup
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,7 +62,7 @@ jobs:
       run: docker cp . ${{ matrix.distros[1] }}:/
 
     - name: Build and test
-      run: docker exec ${{ matrix.distros[1] }} -w aerospike-client-python ./build-${{ matrix.distros[1] }}.sh
+      run: docker exec ${{ matrix.distros[1] }} ./build-${{ matrix.distros[1] }}.sh -w aerospike-client-python
       working-directory: .github/workflows
 
     - name: Cleanup

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,20 +55,15 @@ jobs:
       with:
         submodules: recursive
 
-    # Use this to get current branch of workflow
-    - name: Inject slug/short variables
-      uses: rlespinasse/github-slug-action@v4
-      with:
-        short-length: 8 # Same as v3 and before
-
     - name: Run Alpine container
       run: docker run --name ${{ matrix.distros[1] }} --network host --detach ${{ matrix.distros[0] }}:latest tail -f /dev/null
 
-    - name: Copy build and test script to container
+    - name: Copy repo to container
       run: docker cp . ${{ matrix.distros[1] }}:/
 
     - name: Build and test
       run: docker exec ${{ matrix.distros[1] }} ./build-${{ matrix.distros[1] }}.sh
+      working-directory: .github/workflows
 
     - name: Cleanup
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,8 +62,7 @@ jobs:
       run: docker cp . ${{ matrix.distros[1] }}:/aerospike-client-python
 
     - name: Build and test
-      run: docker exec ${{ matrix.distros[1] }} ./build-${{ matrix.distros[1] }}.sh -w aerospike-client-python
-      working-directory: .github/workflows
+      run: docker exec ${{ matrix.distros[1] }} /aerospike-client-python/build-${{ matrix.distros[1] }}.sh
 
     - name: Cleanup
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,7 +59,7 @@ jobs:
       run: docker run --name ${{ matrix.distros[1] }} --network host --detach ${{ matrix.distros[0] }}:latest tail -f /dev/null
 
     - name: Copy repo to container
-      run: docker cp . ${{ matrix.distros[1] }}:/
+      run: docker cp . ${{ matrix.distros[1] }}:/aerospike-client-python
 
     - name: Build and test
       run: docker exec ${{ matrix.distros[1] }} ./build-${{ matrix.distros[1] }}.sh -w aerospike-client-python

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,7 +62,7 @@ jobs:
       run: docker cp . ${{ matrix.distros[1] }}:/
 
     - name: Build and test
-      run: docker exec ${{ matrix.distros[1] }} ./build-${{ matrix.distros[1] }}.sh
+      run: docker exec ${{ matrix.distros[1] }} -w aerospike-client-python ./build-${{ matrix.distros[1] }}.sh
       working-directory: .github/workflows
 
     - name: Cleanup

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,6 +52,8 @@ jobs:
       run: docker run -d --name aerospike -p 3000-3002:3000-3002 aerospike/aerospike-server
 
     - uses: actions/checkout@v2
+      with:
+        submodules: recursive
 
     # Use this to get current branch of workflow
     - name: Inject slug/short variables
@@ -63,11 +65,10 @@ jobs:
       run: docker run --name ${{ matrix.distros[1] }} --network host --detach ${{ matrix.distros[0] }}:latest tail -f /dev/null
 
     - name: Copy build and test script to container
-      run: docker cp ./build-${{ matrix.distros[1] }}.sh ${{ matrix.distros[1] }}:/
-      working-directory: .github/workflows
+      run: docker cp . ${{ matrix.distros[1] }}:/
 
     - name: Build and test
-      run: docker exec ${{ matrix.distros[1] }} ./build-${{ matrix.distros[1] }}.sh ${{ env.GITHUB_REPOSITORY_OWNER_PART_SLUG_URL }} ${{ env.GITHUB_REF_NAME }}
+      run: docker exec ${{ matrix.distros[1] }} ./build-${{ matrix.distros[1] }}.sh
 
     - name: Cleanup
       run: |

--- a/doc/aerospike.rst
+++ b/doc/aerospike.rst
@@ -611,7 +611,6 @@ Only the `hosts` key is required; the rest of the keys are optional.
             The counted error types are any error that causes the connection to close (socket errors and client timeouts), server device overload and server timeouts.
 
             The application should backoff or reduce the transaction load until :exc:`~aerospike.exception.MaxErrorRateExceeded` stops being returned.
-            If max_error_rate is zero, there is no error limit.
 
             Default: ``100``
         * **error_rate_window** (:class:`int`)

--- a/doc/aerospike.rst
+++ b/doc/aerospike.rst
@@ -607,9 +607,9 @@ Only the `hosts` key is required; the rest of the keys are optional.
             Maximum number of pipeline connections allowed for each node
         * **max_error_rate** (:class:`int`)
             Maximum number of errors allowed per node per ``error_rate_window`` before backoff algorithm returns :exc:`~aerospike.exception.MaxErrorRateExceeded` for database commands to that node. If ``max_error_rate`` is zero, there is no error limit.
-            
+
             The counted error types are any error that causes the connection to close (socket errors and client timeouts), server device overload and server timeouts.
-            
+
             The application should backoff or reduce the transaction load until :exc:`~aerospike.exception.MaxErrorRateExceeded` stops being returned.
             If max_error_rate is zero, there is no error limit.
 

--- a/doc/aerospike.rst
+++ b/doc/aerospike.rst
@@ -605,6 +605,15 @@ Only the `hosts` key is required; the rest of the keys are optional.
             Default: ``0``
         * **max_conns_per_node** (:class:`int`)
             Maximum number of pipeline connections allowed for each node
+        * **max_error_rate** (:class:`int`)
+            Maximum number of error limits.
+            If max_error_rate is zero, there is no error limit.
+
+            Default: ``100``
+        * **error_rate_window** (:class:`int`)
+            The number of cluster tend iterations that defines the window for max_error_rate.
+
+            Default: ``1``
         * **tend_interval** (:class:`int`)
             Polling interval in milliseconds for tending the cluster
 

--- a/doc/aerospike.rst
+++ b/doc/aerospike.rst
@@ -606,12 +606,16 @@ Only the `hosts` key is required; the rest of the keys are optional.
         * **max_conns_per_node** (:class:`int`)
             Maximum number of pipeline connections allowed for each node
         * **max_error_rate** (:class:`int`)
-            Maximum number of error limits.
+            Maximum number of errors allowed per node per ``error_rate_window`` before backoff algorithm returns :exc:`~aerospike.exception.MaxErrorRateExceeded` for database commands to that node. If ``max_error_rate`` is zero, there is no error limit.
+            
+            The counted error types are any error that causes the connection to close (socket errors and client timeouts), server device overload and server timeouts.
+            
+            The application should backoff or reduce the transaction load until :exc:`~aerospike.exception.MaxErrorRateExceeded` stops being returned.
             If max_error_rate is zero, there is no error limit.
 
             Default: ``100``
         * **error_rate_window** (:class:`int`)
-            The number of cluster tend iterations that defines the window for max_error_rate.
+            The number of cluster tend iterations that defines the window for ``max_error_rate``. One tend iteration is defined as ``tend_interval`` plus the time to tend all nodes. At the end of the window, the error count is reset to zero and backoff state is removed on all nodes.
 
             Default: ``1``
         * **tend_interval** (:class:`int`)

--- a/doc/exception.rst
+++ b/doc/exception.rst
@@ -80,6 +80,12 @@ Client Errors
 
     Subclass of :py:exc:`~aerospike.exception.ClientError`.
 
+.. py:exception:: MaxErrorRateExceeded
+
+    The operation was not performed because the maximum error rate has been exceeded.
+
+    Subclass of :py:exc:`~aerospike.exception.ClientError`.
+
 Server Errors
 -------------
 

--- a/src/include/exception_types.h
+++ b/src/include/exception_types.h
@@ -59,6 +59,7 @@ struct exceptions {
     PyObject *ConnectionError;
     PyObject *BatchFailed;            //-16
     PyObject *NoResponse;             //-15
+    PyObject *MaxErrorRateExceeded;   //-14
     PyObject *MaxRetriesExceeded;     //-12
     PyObject *TLSError;               //-9
     PyObject *InvalidNodeError;       //-8

--- a/src/main/client/type.c
+++ b/src/main/client/type.c
@@ -1325,18 +1325,22 @@ static int AerospikeClient_Type_Init(AerospikeClient *self, PyObject *args,
     // max_error_rate
     PyObject *py_max_error_rate =
         PyDict_GetItemString(py_config, "max_error_rate");
+    Py_XINCREF(py_max_error_rate);
     if (py_max_error_rate &&
         (PyInt_Check(py_max_error_rate) || PyLong_Check(py_max_error_rate))) {
         config.max_error_rate = PyInt_AsLong(py_max_error_rate);
     }
+    Py_XDECREF(py_max_error_rate);
 
     // error_rate_window
     PyObject *py_error_rate_window =
         PyDict_GetItemString(py_config, "error_rate_window");
+        Py_XINCREF(py_config);
     if (py_error_rate_window &&
         (PyInt_Check(py_error_rate_window) || PyLong_Check(py_error_rate_window))) {
         config.error_rate_window = PyInt_AsLong(py_error_rate_window);
     }
+    Py_XDECREF(py_error_rate_window);
 
     //conn_timeout_ms
     PyObject *py_connect_timeout =

--- a/src/main/client/type.c
+++ b/src/main/client/type.c
@@ -1335,7 +1335,7 @@ static int AerospikeClient_Type_Init(AerospikeClient *self, PyObject *args,
     // error_rate_window
     PyObject *py_error_rate_window =
         PyDict_GetItemString(py_config, "error_rate_window");
-        Py_XINCREF(py_config);
+    Py_XINCREF(py_error_rate_window);
     if (py_error_rate_window &&
         PyLong_Check(py_error_rate_window)) {
         config.error_rate_window = PyInt_AsLong(py_error_rate_window);

--- a/src/main/client/type.c
+++ b/src/main/client/type.c
@@ -1326,8 +1326,7 @@ static int AerospikeClient_Type_Init(AerospikeClient *self, PyObject *args,
     PyObject *py_max_error_rate =
         PyDict_GetItemString(py_config, "max_error_rate");
     Py_XINCREF(py_max_error_rate);
-    if (py_max_error_rate &&
-        PyLong_Check(py_max_error_rate)) {
+    if (py_max_error_rate && PyLong_Check(py_max_error_rate)) {
         config.max_error_rate = PyLong_AsLong(py_max_error_rate);
     }
     Py_XDECREF(py_max_error_rate);
@@ -1336,8 +1335,7 @@ static int AerospikeClient_Type_Init(AerospikeClient *self, PyObject *args,
     PyObject *py_error_rate_window =
         PyDict_GetItemString(py_config, "error_rate_window");
     Py_XINCREF(py_error_rate_window);
-    if (py_error_rate_window &&
-        PyLong_Check(py_error_rate_window)) {
+    if (py_error_rate_window && PyLong_Check(py_error_rate_window)) {
         config.error_rate_window = PyInt_AsLong(py_error_rate_window);
     }
     Py_XDECREF(py_error_rate_window);

--- a/src/main/client/type.c
+++ b/src/main/client/type.c
@@ -1327,7 +1327,7 @@ static int AerospikeClient_Type_Init(AerospikeClient *self, PyObject *args,
         PyDict_GetItemString(py_config, "max_error_rate");
     Py_XINCREF(py_max_error_rate);
     if (py_max_error_rate &&
-        (PyInt_Check(py_max_error_rate) || PyLong_Check(py_max_error_rate))) {
+        PyLong_Check(py_max_error_rate)) {
         config.max_error_rate = PyInt_AsLong(py_max_error_rate);
     }
     Py_XDECREF(py_max_error_rate);
@@ -1337,7 +1337,7 @@ static int AerospikeClient_Type_Init(AerospikeClient *self, PyObject *args,
         PyDict_GetItemString(py_config, "error_rate_window");
         Py_XINCREF(py_config);
     if (py_error_rate_window &&
-        (PyInt_Check(py_error_rate_window) || PyLong_Check(py_error_rate_window))) {
+        PyLong_Check(py_error_rate_window)) {
         config.error_rate_window = PyInt_AsLong(py_error_rate_window);
     }
     Py_XDECREF(py_error_rate_window);

--- a/src/main/client/type.c
+++ b/src/main/client/type.c
@@ -1328,7 +1328,7 @@ static int AerospikeClient_Type_Init(AerospikeClient *self, PyObject *args,
     Py_XINCREF(py_max_error_rate);
     if (py_max_error_rate &&
         PyLong_Check(py_max_error_rate)) {
-        config.max_error_rate = PyInt_AsLong(py_max_error_rate);
+        config.max_error_rate = PyLong_AsLong(py_max_error_rate);
     }
     Py_XDECREF(py_max_error_rate);
 

--- a/src/main/client/type.c
+++ b/src/main/client/type.c
@@ -1322,6 +1322,22 @@ static int AerospikeClient_Type_Init(AerospikeClient *self, PyObject *args,
         config.max_conns_per_node = PyInt_AsLong(py_max_conns);
     }
 
+    // max_error_rate
+    PyObject *py_max_error_rate =
+        PyDict_GetItemString(py_config, "max_error_rate");
+    if (py_max_error_rate &&
+        (PyInt_Check(py_max_error_rate) || PyLong_Check(py_max_error_rate))) {
+        config.max_error_rate = PyInt_AsLong(py_max_error_rate);
+    }
+
+    // error_rate_window
+    PyObject *py_error_rate_window =
+        PyDict_GetItemString(py_config, "error_rate_window");
+    if (py_error_rate_window &&
+        (PyInt_Check(py_error_rate_window) || PyLong_Check(py_error_rate_window))) {
+        config.error_rate_window = PyInt_AsLong(py_error_rate_window);
+    }
+
     //conn_timeout_ms
     PyObject *py_connect_timeout =
         PyDict_GetItemString(py_config, "connect_timeout");

--- a/src/main/exception.c
+++ b/src/main/exception.c
@@ -244,6 +244,15 @@ PyObject *AerospikeException_New(void)
     PyObject_SetAttrString(exceptions_array.NoResponse, "code", py_code);
     Py_DECREF(py_code);
 
+    // max errors limit reached, AEROSPIKE_MAX_ERROR_RATE, -14
+    exceptions_array.MaxErrorRateExceeded = PyErr_NewException(
+        "exception.MaxErrorRateExceeded", exceptions_array.ClientError, NULL);
+    Py_INCREF(exceptions_array.MaxErrorRateExceeded);
+    PyModule_AddObject(module, "MaxErrorRateExceeded", exceptions_array.MaxErrorRateExceeded);
+    py_code = PyInt_FromLong(AEROSPIKE_MAX_ERROR_RATE);
+    PyObject_SetAttrString(exceptions_array.MaxErrorRateExceeded, "code", py_code);
+    Py_DECREF(py_code);
+
     // max retries exceeded, AEROSPIKE_ERR_MAX_RETRIES_EXCEEDED, -12
     exceptions_array.MaxRetriesExceeded = PyErr_NewException(
         "exception.MaxRetriesExceeded", exceptions_array.ClientError, NULL);

--- a/src/main/exception.c
+++ b/src/main/exception.c
@@ -248,9 +248,11 @@ PyObject *AerospikeException_New(void)
     exceptions_array.MaxErrorRateExceeded = PyErr_NewException(
         "exception.MaxErrorRateExceeded", exceptions_array.ClientError, NULL);
     Py_INCREF(exceptions_array.MaxErrorRateExceeded);
-    PyModule_AddObject(module, "MaxErrorRateExceeded", exceptions_array.MaxErrorRateExceeded);
+    PyModule_AddObject(module, "MaxErrorRateExceeded",
+                       exceptions_array.MaxErrorRateExceeded);
     py_code = PyInt_FromLong(AEROSPIKE_MAX_ERROR_RATE);
-    PyObject_SetAttrString(exceptions_array.MaxErrorRateExceeded, "code", py_code);
+    PyObject_SetAttrString(exceptions_array.MaxErrorRateExceeded, "code",
+                           py_code);
     Py_DECREF(py_code);
 
     // max retries exceeded, AEROSPIKE_ERR_MAX_RETRIES_EXCEEDED, -12

--- a/test/new_tests/as_errors.py
+++ b/test/new_tests/as_errors.py
@@ -18,6 +18,12 @@
 #
 #    Client Errors
 #
+
+#
+#    Max errors limit reached.
+#
+AEROSPIKE_MAX_ERROR_RATE = -14
+
 #
 #    Synchronous connection error.
 #

--- a/test/new_tests/as_status_codes.py
+++ b/test/new_tests/as_status_codes.py
@@ -8,6 +8,7 @@ Roughly maps to: exception_types.h
 
 class AerospikeStatus(object):
     AEROSPIKE_OK = 0
+    AEROSPIKE_MAX_ERROR_RATE = -14
     AEROSPIKE_SERVER_ERROR = -10
     AEROSPIKE_INVALID_HOST = -4
     AEROSPIKE_ERR_CLIENT = -1

--- a/test/new_tests/test_max_error_rate.py
+++ b/test/new_tests/test_max_error_rate.py
@@ -1,0 +1,106 @@
+# -*- coding: utf-8 -*-
+
+from .test_base_class import TestBaseClass
+from .as_status_codes import AerospikeStatus
+import aerospike
+from aerospike import exception as e
+import time
+
+DEFAULT_MAX_ERROR_RATE = 100
+
+class TestMaxErrorRate(TestBaseClass):
+
+    def test_max_error_rate_is_default(self):
+        """
+        error count reaches default limit.
+        """
+        config = TestBaseClass.get_connection_config()
+        config["tend_interval"] = 1000 * 100 # prevent for healthcheck thread to reset error count
+        client = aerospike.client(config)
+
+        query = client.query("test", "demo")
+
+        def callback(input_tuple):
+            raise Exception
+
+        for i in range(2 * DEFAULT_MAX_ERROR_RATE):
+            
+            try:
+                query.foreach(callback)
+            except e.ClientError as ex:
+                if i <= DEFAULT_MAX_ERROR_RATE:
+                    assert ex.code == AerospikeStatus.AEROSPIKE_ERR_CLIENT
+                else:
+                    assert ex.code == AerospikeStatus.AEROSPIKE_MAX_ERROR_RATE
+
+
+    def test_max_error_rate_is_over_default(self):
+        """
+        error count reaches limit over default.
+        """
+        MAX_ERROR_RATE = DEFAULT_MAX_ERROR_RATE + 1
+        config = TestBaseClass.get_connection_config()
+        config["tend_interval"] = 1000 * 100 # prevent for healthcheck thread to reset error count
+        config["max_error_rate"] = MAX_ERROR_RATE
+        client = aerospike.client(config)
+
+        query = client.query("test", "demo")
+
+        def callback(input_tuple):
+            raise Exception
+
+        for i in range(2 * MAX_ERROR_RATE):
+            try:
+                query.foreach(callback)
+            except e.ClientError as ex:
+                if i <= MAX_ERROR_RATE:
+                    assert ex.code == AerospikeStatus.AEROSPIKE_ERR_CLIENT
+                else:
+                    assert ex.code == AerospikeStatus.AEROSPIKE_MAX_ERROR_RATE
+    
+    def test_max_error_rate_is_below_default(self):
+        """
+        error count reaches limit below default.
+        """
+        MAX_ERROR_RATE = DEFAULT_MAX_ERROR_RATE - 1
+        config = TestBaseClass.get_connection_config()
+        config["tend_interval"] = 1000 * 100 # prevent for healthcheck thread to reset error count
+        config["max_error_rate"] = MAX_ERROR_RATE
+        client = aerospike.client(config)
+
+        query = client.query("test", "demo")
+
+        def callback(input_tuple):
+
+            raise Exception
+
+        for i in range(2 * MAX_ERROR_RATE):
+            try:
+                query.foreach(callback)
+            except e.ClientError as ex:
+                if i <= MAX_ERROR_RATE:
+                    assert ex.code == AerospikeStatus.AEROSPIKE_ERR_CLIENT
+                else:
+                    assert ex.code == AerospikeStatus.AEROSPIKE_MAX_ERROR_RATE
+
+    def test_max_error_rate_is_reseted_by_healthcheck_thread(self):
+        """
+        error count is reseted by healthcheck thread.
+        """
+        MAX_ERROR_RATE = 2
+        config = TestBaseClass.get_connection_config()
+        config["tend_interval"] = 250 # mininum tend_interval (250ms)
+        config["max_error_rate"] = MAX_ERROR_RATE
+        client = aerospike.client(config)
+
+        query = client.query("test", "demo")
+
+        def callback(input_tuple):
+            time.sleep(2) # wait for mote than tend_interval
+            raise Exception
+
+        for i in range(2 * MAX_ERROR_RATE):
+            try:
+                query.foreach(callback)
+            except e.ClientError as ex:
+                assert ex.code == AerospikeStatus.AEROSPIKE_ERR_CLIENT

--- a/test/new_tests/test_max_error_rate.py
+++ b/test/new_tests/test_max_error_rate.py
@@ -8,6 +8,7 @@ import time
 
 DEFAULT_MAX_ERROR_RATE = 100
 
+
 class TestMaxErrorRate(TestBaseClass):
 
     @pytest.mark.parametrize(
@@ -25,7 +26,7 @@ class TestMaxErrorRate(TestBaseClass):
         error count reaches default limit.
         """
         config = TestBaseClass.get_connection_config()
-        config["tend_interval"] = 1000 * 100 # prevent for healthcheck thread to reset error count
+        config["tend_interval"] = 1000 * 100  # prevent for healthcheck thread to reset error count
         config["max_error_rate"] = max_error_rate
         client = aerospike.client(config)
 
@@ -49,14 +50,14 @@ class TestMaxErrorRate(TestBaseClass):
         """
         MAX_ERROR_RATE = 2
         config = TestBaseClass.get_connection_config()
-        config["tend_interval"] = 250 # mininum tend_interval (250ms)
+        config["tend_interval"] = 250  # mininum tend_interval (250ms)
         config["max_error_rate"] = MAX_ERROR_RATE
         client = aerospike.client(config)
 
         query = client.query("test", "demo")
 
         def callback(input_tuple):
-            time.sleep(2) # wait for mote than tend_interval
+            time.sleep(2)  # wait for mote than tend_interval
             raise Exception
 
         for i in range(2 * MAX_ERROR_RATE):
@@ -69,20 +70,19 @@ class TestMaxErrorRate(TestBaseClass):
         """
         max_error_rate is zero(unlimited).
         """
-        MAX_ERROR_RATE = 0
         config = TestBaseClass.get_connection_config()
-        config["tend_interval"] = 3000
-        config["max_error_rate"] = MAX_ERROR_RATE
-        config["error_rate_window"] = 3
+        config["tend_interval"] = 1000
+        config["error_rate_window"] = 6
         client = aerospike.client(config)
-        
+
         query = client.query("test", "demo")
-        
-        def callback(input_tuple):
+
+        def callback(_):
             time.sleep(1)
             raise Exception
-        
-        for i in range(6):
+
+        # MaxRetriesExceeded should never be thrown
+        for _ in range(6):
             try:
                 query.foreach(callback)
             except e.ClientError as ex:


### PR DESCRIPTION
enables to add [max_error_rate](https://github.com/aerospike/aerospike-client-c/blob/f7af9db267abe6d61bd6a2b6fc2424d3687e6d7d/src/include/aerospike/as_config.h#L584) and [error_rate_window](https://github.com/aerospike/aerospike-client-c/blob/f7af9db267abe6d61bd6a2b6fc2424d3687e6d7d/src/include/aerospike/as_config.h#L594) to config.