### PR TITLE
[CLIENT-2214] Ensure integration tests can run on lowest supported server version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -274,6 +274,40 @@ jobs:
       run: python -m pytest ./new_tests -vv
       working-directory: test
 
+  test-server-5.7:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+
+    - uses: actions/setup-python@v2
+      with:
+        python-version: "3.7"
+        architecture: 'x64'
+
+    - uses: actions/download-artifact@v3
+      with:
+        name: wheel-3.7
+
+    - name: Install client
+      run: pip install *.whl
+
+    - name: Install test dependencies
+      run: pip install -r test/requirements.txt
+
+    - name: Run server 5.7
+      run: docker run -d --name aerospike -p 3000-3002:3000-3002 aerospike/aerospike-server:5.7.0.0
+
+    - name: Wait for database to be ready
+      # Should be ready after 3 seconds
+      run: sleep 3
+
+    - name: Run tests
+      run: python -m pytest ./new_tests
+      working-directory: test
+
   test-ee:
     runs-on: ubuntu-latest
     needs: build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -298,7 +298,7 @@ jobs:
       run: pip install -r test/requirements.txt
 
     - name: Run server 5.7
-      run: docker run -d --name aerospike -p 3000-3002:3000-3002 aerospike/aerospike-server:5.7.0.0
+      run: docker run -d --name aerospike -p 3000-3002:3000-3002 aerospike/aerospike-server:5.7.0.7
 
     - name: Wait for database to be ready
       # Should be ready after 3 seconds

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -297,8 +297,10 @@ jobs:
     - name: Install test dependencies
       run: pip install -r test/requirements.txt
 
-    - name: Run server 5.7
-      run: docker run -d --name aerospike -p 3000-3002:3000-3002 aerospike/aerospike-server:5.7.0.7
+    - name: Run lowest supported server
+      run: |
+        SERVER_VERSION=$(curl -s "https://registry.hub.docker.com/v2/repositories/aerospike/aerospike-server/tags?page_size=100" | jq '.results[] | select(.name | startswith("6.0")).name' -r | head -n 1)
+        docker run -d --name aerospike -p 3000-3002:3000-3002 aerospike/aerospike-server:$SERVER_VERSION
 
     - name: Wait for database to be ready
       # Should be ready after 3 seconds

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -274,7 +274,7 @@ jobs:
       run: python -m pytest ./new_tests -vv
       working-directory: test
 
-  test-server-5.7:
+  test-lowest-supported-server:
     runs-on: ubuntu-latest
     needs: build
     steps:


### PR DESCRIPTION
Server 5.7 is reaching end of life soon so test server 6.0 instead