### PR TITLE
[CLIENT-2228] Add support for expression values

### DIFF
--- a/aerospike_helpers/expressions/base.py
+++ b/aerospike_helpers/expressions/base.py
@@ -41,15 +41,16 @@ TypeGeo = Union[_BaseExpr, aerospike.GeoJSON]
 # Value Expressions
 ###################
 
-class Val(_BaseExpr):
+class Val(_GenericExpr):
     """Create an expression that returns a nil value.
     """
 
-    _op = _ExprOp._AS_EXP_CODE_AS_VAL
-
     def __init__(self, value: Any):
-        self._children = (value,)
-        super().__init__()
+        super().__init__(
+            op=_ExprOp._AS_EXP_CODE_AS_VAL,
+            rt=None,
+            fixed={_Keys.VALUE_KEY: value}
+        )
 
 
 class Unknown(_BaseExpr):

--- a/aerospike_helpers/expressions/base.py
+++ b/aerospike_helpers/expressions/base.py
@@ -49,6 +49,8 @@ class Val(_BaseExpr):
     _op = _ExprOp._AS_EXP_CODE_AS_VAL
 
     def __init__(self, value: Any):
+        """:return: (value)
+        """
         self._fixed = {_Keys.VALUE_KEY: value}
         super().__init__()
 

--- a/aerospike_helpers/expressions/base.py
+++ b/aerospike_helpers/expressions/base.py
@@ -41,6 +41,16 @@ TypeGeo = Union[_BaseExpr, aerospike.GeoJSON]
 # Value Expressions
 ###################
 
+class Val(_BaseExpr):
+    """Create an expression that returns a nil value.
+    """
+
+    _op = _ExprOp._AS_EXP_CODE_AS_VAL
+
+    def __init__(self, value: Any):
+        self._children = (value,)
+        super().__init__()
+
 
 class Unknown(_BaseExpr):
     """Create an 'Unknown' expression, which allows an operation expression

--- a/aerospike_helpers/expressions/base.py
+++ b/aerospike_helpers/expressions/base.py
@@ -41,16 +41,16 @@ TypeGeo = Union[_BaseExpr, aerospike.GeoJSON]
 # Value Expressions
 ###################
 
-class Val(_GenericExpr):
-    """Create an expression that returns a nil value.
+class Val(_BaseExpr):
+    """
+    Create an expression that returns a value.
     """
 
+    _op = _ExprOp._AS_EXP_CODE_AS_VAL
+
     def __init__(self, value: Any):
-        super().__init__(
-            op=_ExprOp._AS_EXP_CODE_AS_VAL,
-            rt=None,
-            fixed={_Keys.VALUE_KEY: value}
-        )
+        self._fixed = {_Keys.VALUE_KEY: value}
+        super().__init__()
 
 
 class Unknown(_BaseExpr):

--- a/aerospike_helpers/expressions/resources.py
+++ b/aerospike_helpers/expressions/resources.py
@@ -85,9 +85,7 @@ class _ExprOp:  # TODO replace this with an enum
     DEF = 126
 
     _AS_EXP_CODE_AS_VAL = 128
-
     # virtual ops
-
     _AS_EXP_CODE_CALL_VOP_START = 139
     _AS_EXP_CODE_CDT_LIST_CRMOD = 140
     _AS_EXP_CODE_CDT_LIST_MOD = 141
@@ -109,6 +107,7 @@ class ResultType:
     """
     Flags used to indicate expression value_type.
     """
+
     BOOLEAN = 1
     INTEGER = 2
     STRING = 3
@@ -149,21 +148,16 @@ class _BaseExpr(_AtomExpr):
     def _get_op(self) -> TypeCompiledOp:
         return (self._op, self._rt, self._fixed, len(self._children))
 
-    # Raw values can be passed to expressions as arguments directly
-    # or they can be represented by expressions
-    def _vop(self, v, is_raw_value: bool) -> TypeCompiledOp:
+    def _vop(self, v) -> TypeCompiledOp:
         return (
-            _ExprOp.VAL if is_raw_value else self._op,
+            _ExprOp.VAL,
             None,
             {_Keys.VALUE_KEY: v},
             0,
         )
 
     def compile(self) -> TypeExpression:
-        if self._op == _ExprOp._AS_EXP_CODE_AS_VAL:
-            expression = [self._vop(self._children[0], True)]
-        else:
-            expression = [self._get_op()]
+        expression = [self._get_op()]
         # type: 'TypeExpression'
         work = chain(self._children)
 
@@ -174,15 +168,11 @@ class _BaseExpr(_AtomExpr):
                 break
 
             if isinstance(item, _BaseExpr):
-                # Expression object
-                if item._op == _ExprOp._AS_EXP_CODE_AS_VAL:
-                    expression.append(self._vop(item._children[0], False))
-                else:
-                    expression.append(item._get_op())
-                    work = chain(item._children, work)
+                expression.append(item._get_op())
+                work = chain(item._children, work)
             else:
-                # Should be a raw value, such as a str, bin, int, float, etc.
-                expression.append(self._vop(item, True))
+                # Should be a str, bin, int, float, etc.
+                expression.append(self._vop(item))
 
         return expression
 

--- a/src/main/convert_expressions.c
+++ b/src/main/convert_expressions.c
@@ -631,7 +631,8 @@ add_expr_macros(AerospikeClient *self, as_static_pool *static_pool,
 
             APPEND_ARRAY(0, BIN_EXPR());
             break;
-        case VAL:;
+        case VAL:
+        case _AS_EXP_CODE_AS_VAL:
             as_exp_entry tmp_expr;
             if (get_exp_val_from_pyval(
                     self, static_pool, serializer_type, &tmp_expr,

--- a/src/main/convert_expressions.c
+++ b/src/main/convert_expressions.c
@@ -633,7 +633,7 @@ add_expr_macros(AerospikeClient *self, as_static_pool *static_pool,
             APPEND_ARRAY(0, BIN_EXPR());
             break;
         case VAL:
-        case _AS_EXP_CODE_AS_VAL:
+        case _AS_EXP_CODE_AS_VAL:;
             as_exp_entry tmp_expr;
             if (get_exp_val_from_pyval(
                     self, static_pool, serializer_type, &tmp_expr,

--- a/src/main/convert_expressions.c
+++ b/src/main/convert_expressions.c
@@ -216,6 +216,7 @@ static as_status get_expr_size(int *size_to_alloc, int *intermediate_exprs_size,
 
     static const int EXPR_SIZES[] = {
         [BIN] = EXP_SZ(as_exp_bin_int(0)),
+        [_AS_EXP_CODE_AS_VAL] = EXP_SZ(as_exp_val(NULL)),
         [VAL] = EXP_SZ(as_exp_val(
             NULL)), // NOTE if I don't count vals I don't need to subtract from other ops // MUST count these for expressions with var args.
         [EQ] = EXP_SZ(as_exp_cmp_eq(

--- a/test/new_tests/test_expressions_base.py
+++ b/test/new_tests/test_expressions_base.py
@@ -159,11 +159,19 @@ class TestExpressions(TestBaseClass):
         request.addfinalizer(teardown)
 
     def test_val_pos(self):
+        expr = Val(2).compile()
         ops = [
-            expressions.expression_write("extra", Val(1).compile())
+            expressions.expression_write("extra", expr)
         ]
         record = self.as_connection.operate(("test", "demo", _NUM_RECORDS), ops)
-        assert record[2]["extra"] == 1
+
+        expr = Eq(IntBin("extra"), Val(2))
+        record = self.as_connection.get(("test", "demo", _NUM_RECORDS), policy={"expressions": expr.compile()})
+        assert record[2]["extra"] == 2
+
+        with pytest.raises(e.FilteredOut):
+            expr = Eq(IntBin("extra"), Val(4))
+            self.as_connection.get(("test", "demo", _NUM_RECORDS), policy={"expressions": expr.compile()})
 
     @pytest.mark.xfail(reason="Will fail on storage engine device.")
     def test_device_size_pos(self):

--- a/test/new_tests/test_expressions_base.py
+++ b/test/new_tests/test_expressions_base.py
@@ -35,6 +35,7 @@ from aerospike_helpers.expressions import (
     Unknown,
     Var,
     VoidTime,
+    Val
 )
 from aerospike_helpers.operations import expression_operations as expressions
 from aerospike_helpers.operations import operations
@@ -156,6 +157,13 @@ class TestExpressions(TestBaseClass):
             as_connection.remove(("test", "demo", bytearray("b_string", "utf-8")))
 
         request.addfinalizer(teardown)
+
+    def test_val_pos(self):
+        ops = [
+            expressions.expression_write("extra", Val(1).compile())
+        ]
+        record = self.as_connection.operate(("test", "demo", _NUM_RECORDS), ops)
+        assert record[2]["extra"] == 1
 
     @pytest.mark.xfail(reason="Will fail on storage engine device.")
     def test_device_size_pos(self):


### PR DESCRIPTION
Build wheels test passing except for some noise: https://github.com/aerospike/aerospike-client-python/actions/runs/5092347763

**Valgrind**

There seems to be 4 less memory leaks in this branch compared to the stage branch. No new memory errors in this branch were found.

stage branch: https://github.com/aerospike/aerospike-client-python/actions/runs/5092349440/jobs/9153578570
this branch: https://github.com/aerospike/aerospike-client-python/actions/runs/5092345365/jobs/9153569568
