### PR TITLE
[CLIENT-2303] Add support for Amazon Linux 2023

### DIFF
--- a/.github/workflows/build-rpm-based.sh
+++ b/.github/workflows/build-rpm-based.sh
@@ -14,7 +14,3 @@ python3 -m pip install dist/*.whl
 cd test
 python3 -m pip install -r requirements.txt
 python3 -m pytest new_tests/
-
-# Wheel install test
-pip uninstall -y aerospike
-python3 -m pip install aerospike

--- a/.github/workflows/build-rpm-based.sh
+++ b/.github/workflows/build-rpm-based.sh
@@ -5,6 +5,8 @@ set -x
 
 # Executed inside the aerospike-client-python directory
 yum install -y openssl-devel glibc-devel autoconf automake libtool zlib-devel openssl-devel python-devel
+# Amazon Linux 2023's default python doesn't come with pip
+python3 -m ensurepip
 python3 -m pip install build
 python3 -m build
 python3 -m pip install dist/*.whl

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -218,7 +218,10 @@ jobs:
       needs: manylinux_x86_64_no_test
       strategy:
         matrix:
-          image: ["redhat/ubi8", "amazonlinux:2023"]
+          image: [
+            "redhat/ubi8",
+            "amazonlinux:2023"
+          ]
         fail-fast: false
       runs-on: ubuntu-latest
       services:
@@ -238,6 +241,8 @@ jobs:
           name: manylinux-x86_64-cp39-distros
 
       - run: dnf -y install python3.9
+      # Amazon Linux 2023 doesn't come with pip
+      - run: python3.9 -m ensurepip
       - run: python3.9 -m pip install *.whl
 
       - name: Install test dependencies

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -43,9 +43,10 @@ jobs:
     strategy:
       matrix:
         distros: [
-          # Image name, container name
+          # Image name, build-<name> and container name 
           ["alpine", "alpine"],
-          ["redhat/ubi9", "rhel9"]
+          ["redhat/ubi9", "rpm-based"],
+          ["amazonlinux:2023", "rpm-based"]
         ]
       fail-fast: false
     runs-on: ubuntu-latest
@@ -63,7 +64,7 @@ jobs:
         submodules: recursive
 
     - name: Run Alpine container
-      run: docker run --name ${{ matrix.distros[1] }} --network host --detach ${{ matrix.distros[0] }}:latest tail -f /dev/null
+      run: docker run --name ${{ matrix.distros[1] }} --network host --detach ${{ matrix.distros[0] }} tail -f /dev/null
 
     - name: Copy repo to container
       run: docker cp . ${{ matrix.distros[1] }}:/aerospike-client-python
@@ -212,14 +213,19 @@ jobs:
         # Artifact name, not the file name
         name: manylinux-x86_64-cp39-distros
 
-  manylinux_x86_64_rhel8:
+  # Test RPM-based Linux OS's
+  manylinux_x86_64_rpm_based:
       needs: manylinux_x86_64_no_test
+      strategy:
+        matrix:
+          image: ["redhat/ubi8", "amazonlinux:2023"]
+        fail-fast: false
       runs-on: ubuntu-latest
       services:
         aerospike:
           image: ${{ inputs.use-server-rc && 'aerospike.jfrog.io/docker/aerospike/aerospike-server-rc:latest' || 'aerospike/aerospike-server' }}
       container:
-        image: redhat/ubi8
+        image: ${{ matrix.image }}
       steps:
       - run: dnf -y update
       - run: dnf -y install git

--- a/BUILD.md
+++ b/BUILD.md
@@ -16,7 +16,7 @@ The client depends on:
 - OpenSSL 1.1 >= 1.1.1
 - The Aerospike C client
 
-### RedHat and CentOS
+### RedHat, CentOS, Amazon Linux 2023
 
 The following are dependencies for:
 

--- a/README.rst
+++ b/README.rst
@@ -15,6 +15,7 @@ The Python client for Aerospike works with Python 3.7 - 3.11 running on:
 - macOS 11 and 12
 - CentOS 7 Linux
 - RHEL 8 and 9
+- Amazon Linux 2023
 - Debian 8 to 11
 - Ubuntu 20.04 and 22.04
 - Alpine Linux


### PR DESCRIPTION
Build wheels test passes (including cat 1 and 2 tests on amazon linux 2023): https://github.com/aerospike/aerospike-client-python/actions/runs/5060092538

No new memory errors or leaks compared to stage branch:
Valgrind on this branch: https://github.com/aerospike/aerospike-client-python/actions/runs/5059901244
Valgrind on stage: https://github.com/aerospike/aerospike-client-python/actions/runs/5061600174