### PR TITLE
[CLIENT-2363] Document client.admin_query_user[s]_info() and deprecate client.admin_query_user[s]

### DIFF
--- a/doc/client.rst
+++ b/doc/client.rst
@@ -1286,6 +1286,23 @@ user\'s roles. Users are assigned roles, which are collections of \
 
         :raises: one of the :exc:`~aerospike.exception.AdminError` subclasses.
 
+    .. method:: admin_query_user_info (user: str[, policy: dict]) -> dict
+
+        Retrieve roles and other info for a given user.
+
+        :param str user: the username of the user.
+        :param dict policy: optional :ref:`aerospike_admin_policies`.
+
+        :return: a :class:`dict` of user data. See :ref:`admin_user_dict`.
+
+    .. method:: admin_query_users_info ([policy: dict]) -> list
+
+        Retrieve roles and other info for all users.
+
+        :param dict policy: optional :ref:`aerospike_admin_policies`.
+
+        :return: a :class:`list` of users' data. See :ref:`admin_user_dict`.
+
     .. method:: admin_query_user (username[, policy: dict]) -> []
 
         Return the list of roles granted to the specified user.
@@ -1304,6 +1321,43 @@ user\'s roles. Users are assigned roles, which are collections of \
         :param dict policy: optional :ref:`aerospike_admin_policies`.
         :return: a :class:`dict` of roles keyed by username.
         :raises: one of the :exc:`~aerospike.exception.AdminError` subclasses.
+
+.. _admin_user_dict:
+
+User Dictionary
+===============
+
+The user dictionary has the following key-value pairs:
+
+    * ``"read_info"`` (:class:`list[int]`): list of read statistics.
+      List may be :py:obj:`None`. Current statistics by offset are:
+
+       * 0: read quota in records per second
+
+       * 1: single record read transaction rate (TPS)
+
+       * 2: read scan/query record per second rate (RPS)
+
+       * 3: number of limitless read scans/queries
+
+    Future server releases may add additional statistics.
+
+    * ``"write_info"`` (:class:`list[int]`): list of write statistics.
+      List may be :py:obj:`None`. Current statistics by offset are:
+
+       * 0: write quota in records per second
+
+       * 1: single record write transaction rate (TPS)
+
+       * 2: write scan/query record per second rate (RPS)
+
+       * 3: number of limitless write scans/queries
+
+    Future server releases may add additional statistics.
+
+    * ``"conns_in_use"`` (:class:`int`): number of currently open connections.
+
+    * ``"roles"`` (:class:`list[str]`): list of assigned role names.
 
 Scan and Query Constructors
 ---------------------------

--- a/doc/client.rst
+++ b/doc/client.rst
@@ -1314,6 +1314,8 @@ user\'s roles. Users are assigned roles, which are collections of \
 
         :raises: one of the :exc:`~aerospike.exception.AdminError` subclasses.
 
+        .. deprecated:: 12.0.0 :meth:`admin_query_user_info` should be used instead.
+
     .. method:: admin_query_users ([policy: dict]) -> {}
 
         Get the roles of all users.
@@ -1321,6 +1323,8 @@ user\'s roles. Users are assigned roles, which are collections of \
         :param dict policy: optional :ref:`aerospike_admin_policies`.
         :return: a :class:`dict` of roles keyed by username.
         :raises: one of the :exc:`~aerospike.exception.AdminError` subclasses.
+
+        .. deprecated:: 12.0.0 :meth:`admin_query_users_info` should be used instead.
 
 .. _admin_user_dict:
 

--- a/test/new_tests/test_admin_query_user.py
+++ b/test/new_tests/test_admin_query_user.py
@@ -8,6 +8,7 @@ from aerospike import exception as e
 import aerospike
 
 
+@pytest.mark.skip("client.admin_query_user() is deprecated")
 class TestQueryUser(TestBaseClass):
 
     pytestmark = pytest.mark.skipif(

--- a/test/new_tests/test_admin_query_user_info.py
+++ b/test/new_tests/test_admin_query_user_info.py
@@ -61,7 +61,18 @@ class TestQueryUserInfo(TestBaseClass):
 
         time.sleep(2)
         user_details = self.client.admin_query_user_info(user)
-        assert user_details.get("roles") == ["read", "read-write", "sys-admin"]
+        assert user_details.get("roles") == [
+            "read",
+            "read-write",
+            "sys-admin"
+        ]
+        # The user has not read or written anything, so all r/w stats should be 0
+        # NOTE: we don't test the scenario where read_info / write_info is not 0
+        # because it takes time and a lot of transactions for the server to actually record non-zero values
+        assert user_details.get("read_info") == 0
+        assert user_details.get("write_info") == 0
+        # No clients were logged in as this user
+        assert user_details.get("conns_in_use") == 0
 
     def test_query_user_info_with_invalid_timeout_policy_value(self):
 

--- a/test/new_tests/test_admin_query_users.py
+++ b/test/new_tests/test_admin_query_users.py
@@ -8,6 +8,7 @@ from aerospike import exception as e
 import aerospike
 
 
+@pytest.mark.skip("client.admin_query_users() is deprecated")
 class TestQueryUsers(TestBaseClass):
 
     pytestmark = pytest.mark.skipif(

--- a/test/new_tests/test_admin_query_users_info.py
+++ b/test/new_tests/test_admin_query_users_info.py
@@ -54,7 +54,12 @@ class TestQueryUsersInfo(TestBaseClass):
         time.sleep(2)
         user_details = self.client.admin_query_users_info()
 
-        assert user_details.get("example-test").get("roles") == ["read", "read-write", "sys-admin"]
+        # Usage test; doesn't actually test if the server records user data
+        user_details = user_details.get("example-test")
+        assert user_details.get("roles") == ["read", "read-write", "sys-admin"]
+        assert user_details.get("read_info") == 0
+        assert user_details.get("write_info") == 0
+        assert user_details.get("conns_in_use") == 0
 
     def test_query_users_info_with_invalid_timeout_policy_value(self):
 


### PR DESCRIPTION
Updated docs: https://aerospike-python-client--457.org.readthedocs.build/en/457/client.html#aerospike.Client.admin_query_user_info

Build wheels and valgrind workflow runs aren't necessary since the source code and test coverage have not been changed.