### PR TITLE
[CLIENT-2409] Deprecate client.batch_get_ops()

### DIFF
--- a/doc/client.rst
+++ b/doc/client.rst
@@ -305,6 +305,9 @@ Batch Operations
         .. include:: examples/batch_get_ops.py
             :code: python
 
+        .. deprecated:: 12.0.0
+            Use :meth:`batch_operate` instead.
+
     The following batch methods will return a :class:`BatchRecords` object with
     a ``result`` value of ``0`` if one of the following is true:
 

--- a/test/new_tests/test_batch_get_ops.py
+++ b/test/new_tests/test_batch_get_ops.py
@@ -12,6 +12,7 @@ from aerospike import exception as e
 from .test_base_class import TestBaseClass
 
 
+@pytest.mark.skip("client.batch_get_ops() is deprecated")
 class TestBatchExpressionsOperations(TestBaseClass):
     @pytest.fixture(autouse=True)
     def setup(self, request, as_connection):


### PR DESCRIPTION
Docs: https://aerospike-python-client--464.org.readthedocs.build/en/464/client.html#aerospike.Client.batch_get_ops
Tests for function are skipped now: https://github.com/aerospike/aerospike-client-python/actions/runs/5511781847/jobs/10047812433?pr=464#step:10:462