### PR TITLE
[DOCS-861] aerospike.Client: add reference to client constructor in aerospike module

### DIFF
--- a/doc/client.rst
+++ b/doc/client.rst
@@ -47,6 +47,8 @@ Basic example:
 Methods
 =======
 
+To create a new client, use :meth:`aerospike.client`.
+
 .. _aerospike_connection_operations:
 
 Connection


### PR DESCRIPTION
Docs: https://aerospike-python-client--466.org.readthedocs.build/en/466/client.html#methods