### PR TITLE
[CLIENT-2258] Backport 11.*: Convert AS_BYTES_PYTHON server type to Python bytearray

### DIFF
--- a/doc/data_mapping.rst
+++ b/doc/data_mapping.rst
@@ -6,9 +6,19 @@ Python Data Mappings
 
 .. rubric:: How Python types map to server types
 
+Default Behavior
+----------------
+
 By default, the :py:class:`~aerospike.Client` maps the supported Python types to Aerospike server \
 `types <https://docs.aerospike.com/server/guide/data-types/overview>`_. \
-When an unsupported type is encountered by the module, it does not serialize the type and will throw an error.
+When an unsupported type is encountered by the module:
+
+1. When sending data to the server, it does not serialize the type and will throw an error.
+2. When reading `AS_BYTES_PYTHON` types from the server, it returns the raw bytes as a :class:`bytearray`.
+   To deserialize this data, the application must use cPickle instead of relying on the client to do it automatically.
+
+Serializers
+-----------
 
 However, the functions :func:`~aerospike.set_serializer` and :func:`~aerospike.set_deserializer` \
 allow for user-defined functions to handle serialization.
@@ -30,6 +40,9 @@ instance-level pair of functions that handle serialization.
     ``send_bool_as`` can be set so the client writes Python booleans as integers or the Aerospike native boolean type.
 
     All versions before ``6.x`` wrote Python booleans as ``AS_BYTES_PYTHON``.
+
+Data Mappings
+-------------
 
 The following table shows which Python types map directly to Aerospike server types.
 

--- a/doc/spelling_wordlist.txt
+++ b/doc/spelling_wordlist.txt
@@ -3,6 +3,7 @@ lua
 namespace
 geospatial
 serialized
+Serializers
 deserialized
 Aerospike
 aerospike

--- a/src/main/serializer.c
+++ b/src/main/serializer.c
@@ -417,10 +417,23 @@ extern as_status deserialize_based_on_as_bytes_type(AerospikeClient *self,
                                                     as_error *error_p)
 {
     switch (as_bytes_get_type(bytes)) {
-    case AS_BYTES_PYTHON:
-        as_error_update(error_p, AEROSPIKE_ERR,
-                        "Unable to deserialize AS_BYTES_PYTHON bytes");
-        break;
+    case AS_BYTES_PYTHON:;
+        // Automatically convert AS_BYTES_PYTHON server types to bytearrays.
+        // This prevents the client from throwing an exception and
+        // breaking applications that don't handle the exception
+        // in case it still fetches AS_BYTES_PYTHON types stored in the server.
+        // Applications using this client must deserialize the bytearrays
+        // manually with cPickle.
+        uint32_t bval_size = as_bytes_size(bytes);
+        PyObject *py_val = PyByteArray_FromStringAndSize(
+            (char *)as_bytes_get(bytes), bval_size);
+        if (!py_val) {
+            as_error_update(error_p, AEROSPIKE_ERR_CLIENT,
+                            "Unable to deserialize AS_BYTES_PYTHON bytes");
+            goto CLEANUP;
+        }
+        *retval = py_val;
+        as_error_update(error_p, AEROSPIKE_OK, NULL);
     case AS_BYTES_BLOB: {
         if (self->user_deserializer_call_info.callback) {
             execute_user_callback(&self->user_deserializer_call_info, &bytes,


### PR DESCRIPTION
Cherry-picked from #486

Build wheels passes: https://github.com/aerospike/aerospike-client-python/actions/runs/5881769138

Verification that it works:

1. I stored a tuple that was serialized with cPickle using Python client 12.0.0, then stored in the server as an AS_BYTES_PYTHON type.
2. I installed Python client built on this branch (11.2.0) and it returns the AS_BYTES_PYTHON as a bytearray without deserializing it. If you manually deserialize it without using the client, you still get the original object that was serialized with cPickle.

```bash
jnguyen@as-PF3WN8Y6:~/aerospike/aerospike-client-python$ python3 -m pip install aerospike==12.0.0
...
jnguyen@as-PF3WN8Y6:~/aerospike/aerospike-client-python$ python3
Python 3.9.16 (main, Feb  8 2023, 16:50:17) 
[GCC 11.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import aerospike
>>> config = { 'hosts': [ ('127.0.0.1',3000)]}
>>> client = aerospike.client(config).connect()
>>> key = ("test", "demo", 1)
>>> client.put(key, {"a": (1, 2, 3)})
0
>>> exit()
jnguyen@as-PF3WN8Y6:~/aerospike/aerospike-client-python$ python3 -m pip install aerospike-11.2.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl 
...
jnguyen@as-PF3WN8Y6:~/aerospike/aerospike-client-python$ python3
Python 3.9.16 (main, Feb  8 2023, 16:50:17) 
[GCC 11.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import aerospike
>>> config = { 'hosts': [ ('127.0.0.1',3000)]}
>>> client = aerospike.client(config).connect()
>>> key = ("test", "demo", 1)
>>> _, _, bins = client.get(key)
>>> bins["a"]
b'\x80\x04\x95\t\x00\x00\x00\x00\x00\x00\x00K\x01K\x02K\x03\x87\x94.'
>>> import pickle
>>> pickle.loads(bins["a"])
(1, 2, 3)
```

Extra changes:
* Docs: data mapping: add headers