### PR TITLE
[CLIENT-2460] Docs: Add missing constant aerospike.LIST_RETURN_EXISTS

### DIFF
--- a/doc/aerospike.rst
+++ b/doc/aerospike.rst
@@ -1019,6 +1019,10 @@ Return types used by various list operations.
 
     Return value for single key read and value list for range read.
 
+.. data:: LIST_RETURN_EXISTS
+
+    Return true if count of items selected > 0.
+
 .. _aerospike_list_order:
 
 List Order


### PR DESCRIPTION
https://aerospike-python-client--499.org.readthedocs.build/en/499/aerospike.html#aerospike.LIST_RETURN_EXISTS