### PR TITLE
[CLIENT-2468] Docs: add client.index_cdt_create()

### DIFF
--- a/doc/aerospike.rst
+++ b/doc/aerospike.rst
@@ -1414,6 +1414,26 @@ Bin Types
 
     (int): 24
 
+.. _aerospike_index_types:
+
+Index Type
+----------
+
+.. data:: INDEX_TYPE_DEFAULT
+
+    Index a single scalar value.
+
+.. data:: INDEX_TYPE_LIST
+
+    Index all of a list's values.
+
+.. data:: INDEX_TYPE_MAPKEYS
+
+    Index all of a map's keys.
+
+.. data:: INDEX_TYPE_MAPVALUES
+
+    Index all of a map's values.
 
 .. _aerospike_misc_constants:
 
@@ -1443,22 +1463,6 @@ Miscellaneous
     An index whose values are of the aerospike GetJSON data type.
 
 .. seealso:: `Data Types <https://docs.aerospike.com/server/guide/data-types/overview>`_.
-
-.. data:: INDEX_TYPE_DEFAULT
-
-    Index a bin that doesn't contain a complex data type.
-
-.. data:: INDEX_TYPE_LIST
-
-    Index a bin whose contents is an aerospike list.
-
-.. data:: INDEX_TYPE_MAPKEYS
-
-    Index the keys of a bin whose contents is an aerospike map.
-
-.. data:: INDEX_TYPE_MAPVALUES
-
-    Index the values of a bin whose contents is an aerospike map.
 
 .. _aerospike_log_levels:
 

--- a/doc/aerospike.rst
+++ b/doc/aerospike.rst
@@ -1416,8 +1416,8 @@ Bin Types
 
 .. _aerospike_index_types:
 
-Index Type
-----------
+Index Types
+-----------
 
 .. data:: INDEX_TYPE_DEFAULT
 
@@ -1435,20 +1435,10 @@ Index Type
 
     Index all of a map's values.
 
-.. _aerospike_misc_constants:
+.. _aerospike_index_data_types:
 
-Miscellaneous
--------------
-
-.. data:: __version__
-
-    A :class:`str` containing the module's version.
-
-    .. versionadded:: 1.0.54
-
-.. data:: UDF_TYPE_LUA
-
-    UDF type is LUA (which is the only UDF type).
+Data Types
+----------
 
 .. data:: INDEX_STRING
 
@@ -1463,6 +1453,21 @@ Miscellaneous
     An index whose values are of the aerospike GetJSON data type.
 
 .. seealso:: `Data Types <https://docs.aerospike.com/server/guide/data-types/overview>`_.
+
+.. _aerospike_misc_constants:
+
+Miscellaneous
+-------------
+
+.. data:: __version__
+
+    A :class:`str` containing the module's version.
+
+    .. versionadded:: 1.0.54
+
+.. data:: UDF_TYPE_LUA
+
+    UDF type is LUA (which is the only UDF type).
 
 .. _aerospike_log_levels:
 

--- a/doc/client.rst
+++ b/doc/client.rst
@@ -996,7 +996,7 @@ Index Operations
     .. method:: index_cdt_create(ns: str, set: str, bin: str, index_type, index_datatype, index_name: str, ctx: dict[, policy: dict])
 
         Create an complex data type (CDT) index named *index_name* for a scalar, list values, map keys or map values (as defined by *index_type*) and for
-        numeric, string or GeoJSON values (as defined by *index_datatype*)
+        numeric, string, or GeoJSON values (as defined by *index_datatype*)
         on records of the specified *ns*, *set* whose bin is a list or map.
 
         :param str ns: the namespace in the aerospike cluster.

--- a/doc/client.rst
+++ b/doc/client.rst
@@ -993,17 +993,17 @@ Index Operations
             client.index_geo2dsphere_create('test', 'pads', 'loc', 'pads_loc_geo')
             client.close()
 
-    .. method:: index_cdt_create(ns: str, set: str, bin: str, index_type, index_datatype, index_name: str, ctx: dict, [, policy: dict])
+    .. method:: index_cdt_create(ns: str, set: str, bin: str, index_type, index_datatype, index_name: str, ctx: dict[, policy: dict])
 
-        Create an complex data type (CDT) index named *index_name* for list, map keys or map values (as defined by *index_type*) and for
+        Create an complex data type (CDT) index named *index_name* for a scalar, list values, map keys or map values (as defined by *index_type*) and for
         numeric, string or GeoJSON values (as defined by *index_datatype*)
         on records of the specified *ns*, *set* whose bin is a list or map.
 
         :param str ns: the namespace in the aerospike cluster.
         :param str set: the set name.
         :param str bin: the name of bin the secondary index is built on.
-        :param index_type: the type of CDT containing the value.
-        :param index_datatype: the type of value being queried on. The possible arguments are ``aerospike.INDEX_STRING``, ``aerospike.INDEX_NUMERIC`` and ``aerospike.INDEX_GEO2DSPHERE``.
+        :param index_type: the type of the value or CDT containing the value.
+        :param index_datatype: the type of value being queried on. The possible arguments are ``aerospike.INDEX_STRING``, ``aerospike.INDEX_NUMERIC``, and ``aerospike.INDEX_GEO2DSPHERE``.
         :param str index_name: the name of the index.
         :param dict ctx: a dictionary containing the ``"ctx"`` key mapping to a list of contexts.
         :param dict policy: optional :ref:`aerospike_info_policies`.

--- a/doc/client.rst
+++ b/doc/client.rst
@@ -1002,8 +1002,8 @@ Index Operations
         :param str ns: the namespace in the aerospike cluster.
         :param str set: the set name.
         :param str bin: the name of bin the secondary index is built on.
-        :param index_type: the type of the value or CDT containing the value.
-        :param index_datatype: the type of value being queried on. The possible arguments are ``aerospike.INDEX_STRING``, ``aerospike.INDEX_NUMERIC``, and ``aerospike.INDEX_GEO2DSPHERE``.
+        :param index_type: whether we are querying a single scalar value or specific values of a CDT type. See :ref:`aerospike_index_types`.
+        :param index_datatype: the type of value being queried on. See :ref:`aerospike_index_data_types`.
         :param str index_name: the name of the index.
         :param dict ctx: a dictionary containing the ``"ctx"`` key mapping to a list of contexts.
         :param dict policy: optional :ref:`aerospike_info_policies`.

--- a/doc/client.rst
+++ b/doc/client.rst
@@ -995,7 +995,7 @@ Index Operations
 
     .. method:: index_cdt_create(ns: str, set: str, bin: str, index_type, index_datatype, index_name: str, ctx: dict[, policy: dict])
 
-        Create an complex data type (CDT) index named *index_name* for a scalar, list values, map keys or map values (as defined by *index_type*) and for
+        Create an collection data type (CDT) index named *index_name* for a scalar, list values, map keys, or map values (as defined by *index_type*) and for
         numeric, string, or GeoJSON values (as defined by *index_datatype*)
         on records of the specified *ns*, *set* whose bin is a list or map.
 

--- a/doc/client.rst
+++ b/doc/client.rst
@@ -993,6 +993,21 @@ Index Operations
             client.index_geo2dsphere_create('test', 'pads', 'loc', 'pads_loc_geo')
             client.close()
 
+    .. method:: index_cdt_create(ns: str, set: str, bin: str, index_type, index_datatype, index_name: str, ctx: dict, [, policy: dict])
+
+        Create an complex data type (CDT) index named *index_name* for list, map keys or map values (as defined by *index_type*) and for
+        numeric, string or GeoJSON values (as defined by *index_datatype*)
+        on records of the specified *ns*, *set* whose bin is a list or map.
+
+        :param str ns: the namespace in the aerospike cluster.
+        :param str set: the set name.
+        :param str bin: the name of bin the secondary index is built on.
+        :param index_type: the type of CDT containing the value.
+        :param index_datatype: the type of value being queried on. The possible arguments are ``aerospike.INDEX_STRING``, ``aerospike.INDEX_NUMERIC`` and ``aerospike.INDEX_GEO2DSPHERE``.
+        :param str index_name: the name of the index.
+        :param dict ctx: a dictionary containing the ``"ctx"`` key mapping to a list of contexts.
+        :param dict policy: optional :ref:`aerospike_info_policies`.
+        :raises: a subclass of :exc:`~aerospike.exception.AerospikeError`.
 
     .. method:: index_remove(ns: str, name: str[, policy: dict])
 

--- a/test/new_tests/test_cdt_index.py
+++ b/test/new_tests/test_cdt_index.py
@@ -6,6 +6,7 @@ import aerospike
 from aerospike import exception as e
 from .index_helpers import ensure_dropped_index
 from aerospike_helpers import cdt_ctx
+from aerospike import predicates as p
 
 list_index = "list_index"
 list_rank = "list_rank"
@@ -726,3 +727,26 @@ cfasdcalskdcbacfq34915rwcfasdcascnabscbaskjdbcalsjkbcdasc');
             self.as_connection.index_cdt_create()
 
         assert "argument 'ns' (pos 1)" in str(typeError.value)
+
+    @pytest.mark.parametrize(
+        "bin, index_type, index_datatype, ctx, predicate",
+        [(
+            "addr",
+            aerospike.INDEX_TYPE_DEFAULT,
+            aerospike.INDEX_STRING,
+            None,
+            p.equals("addr", "name2")
+        )],
+        # Types of queries
+        ids=[
+            "with no context"
+        ]
+    )
+    def test_queries_with_cdt_index(self, bin, index_type, index_datatype, ctx, predicate):
+        """
+        """
+        self.as_connection.index_cdt_create("test", "demo", bin, index_type, index_datatype, "index_cdt", ctx)
+
+        query: aerospike.Query = self.as_connection.query("test", "demo")
+        query.select("name", "test_age")
+        query.where(predicate)

--- a/test/new_tests/test_query.py
+++ b/test/new_tests/test_query.py
@@ -146,6 +146,19 @@ class TestQuery(TestBaseClass):
         except e.IndexFoundError:
             pass
 
+        try:
+            client.index_cdt_create(
+                "test",
+                "demo",
+                "numeric_map",
+                aerospike.INDEX_TYPE_DEFAULT,
+                aerospike.INDEX_NUMERIC,
+                "numeric_map_cdt_index",
+                {"ctx": ctx_map_index},
+            )
+        except e.IndexFoundError:
+            pass
+
         client.close()
 
     def teardown_class(cls):


### PR DESCRIPTION
`client.index_cdt_create()`: https://aerospike-python-client--504.org.readthedocs.build/en/504/client.html#aerospike.Client.index_cdt_create
`Index types`: https://aerospike-python-client--504.org.readthedocs.build/en/504/aerospike.html#aerospike-index-types
`Index data types`: https://aerospike-python-client--504.org.readthedocs.build/en/504/aerospike.html#aerospike-index-data-types