### PR TITLE
[CLIENT-2077] Add support for reading key ordered maps

### DIFF
--- a/src/main/conversions.c
+++ b/src/main/conversions.c
@@ -1667,6 +1667,7 @@ as_status map_to_pyobject(AerospikeClient *self, as_error *err,
         PyObject *key_ordered_dict_class = AerospikeKeyOrderedDict_Get_Type();
         *py_map =
             PyObject_CallFunctionObjArgs(key_ordered_dict_class, *py_map, NULL);
+        Py_DECREF(*py_map);
     }
 
     if (!*py_map) {

--- a/src/main/conversions.c
+++ b/src/main/conversions.c
@@ -1662,6 +1662,11 @@ as_status map_to_pyobject(AerospikeClient *self, as_error *err,
                           const as_map *map, PyObject **py_map)
 {
     *py_map = PyDict_New();
+    // as_orderedmap has flags set to 1
+    if (map->flags == 1) {
+        PyObject *key_ordered_dict_class = AerospikeKeyOrderedDict_Get_Type();
+        *py_map = PyObject_CallFunctionObjArgs(key_ordered_dict_class, *py_map);
+    }
 
     if (!*py_map) {
         return as_error_update(err, AEROSPIKE_ERR_CLIENT,

--- a/src/main/conversions.c
+++ b/src/main/conversions.c
@@ -1665,7 +1665,8 @@ as_status map_to_pyobject(AerospikeClient *self, as_error *err,
     // as_orderedmap has flags set to 1
     if (map->flags == 1) {
         PyObject *key_ordered_dict_class = AerospikeKeyOrderedDict_Get_Type();
-        *py_map = PyObject_CallFunctionObjArgs(key_ordered_dict_class, *py_map);
+        *py_map =
+            PyObject_CallFunctionObjArgs(key_ordered_dict_class, *py_map, NULL);
     }
 
     if (!*py_map) {

--- a/src/main/conversions.c
+++ b/src/main/conversions.c
@@ -1672,11 +1672,12 @@ as_status map_to_pyobject(AerospikeClient *self, as_error *err,
         PyObject *key_ordered_dict_class = AerospikeKeyOrderedDict_Get_Type();
         PyObject *py_keyordereddict =
             PyObject_CallFunctionObjArgs(key_ordered_dict_class, *py_map, NULL);
+        Py_DECREF(*py_map);
         if (py_keyordereddict == NULL) {
-            Py_DECREF(*py_map);
             return as_error_update(err, AEROSPIKE_ERR_CLIENT,
                                    "Failed to create KeyOrderedDict instance.");
         }
+        *py_map = py_keyordereddict;
     }
 
     conversion_data convd = {

--- a/src/main/conversions.c
+++ b/src/main/conversions.c
@@ -1662,17 +1662,21 @@ as_status map_to_pyobject(AerospikeClient *self, as_error *err,
                           const as_map *map, PyObject **py_map)
 {
     *py_map = PyDict_New();
-    // as_orderedmap has flags set to 1
-    if (map->flags == 1) {
-        PyObject *key_ordered_dict_class = AerospikeKeyOrderedDict_Get_Type();
-        *py_map =
-            PyObject_CallFunctionObjArgs(key_ordered_dict_class, *py_map, NULL);
-        Py_DECREF(*py_map);
-    }
-
     if (!*py_map) {
         return as_error_update(err, AEROSPIKE_ERR_CLIENT,
                                "Failed to allocate memory for dictionary.");
+    }
+
+    // as_orderedmap has flags set to 1
+    if (map->flags == 1) {
+        PyObject *key_ordered_dict_class = AerospikeKeyOrderedDict_Get_Type();
+        PyObject *py_keyordereddict =
+            PyObject_CallFunctionObjArgs(key_ordered_dict_class, *py_map, NULL);
+        if (py_keyordereddict == NULL) {
+            Py_DECREF(*py_map);
+            return as_error_update(err, AEROSPIKE_ERR_CLIENT,
+                                   "Failed to create KeyOrderedDict instance.");
+        }
     }
 
     conversion_data convd = {

--- a/src/main/key_ordered_dict/type.c
+++ b/src/main/key_ordered_dict/type.c
@@ -25,14 +25,6 @@
 
 static PyMethodDef AerospikeKeyOrderedDict_Type_Methods[] = {{NULL}};
 
-static int local_traverse(PyObject *self, visitproc visit, void *arg)
-{
-    AerospikeKeyOrderedDict *self_keyordereddict =
-        (AerospikeKeyOrderedDict *)self;
-    Py_VISIT(&self_keyordereddict->dict);
-    return 0;
-}
-
 /*******************************************************************************
  * PYTHON TYPE HOOKS
  ******************************************************************************/
@@ -56,8 +48,7 @@ static PyTypeObject AerospikeKeyOrderedDict_Type = {
               "This assists in matching key ordered maps\n"
               "through various read operations.\n",
     .tp_methods = AerospikeKeyOrderedDict_Type_Methods,
-    .tp_init = (initproc)AerospikeKeyOrderedDict_Type_Init,
-    .tp_traverse = local_traverse};
+    .tp_init = (initproc)AerospikeKeyOrderedDict_Type_Init};
 
 PyTypeObject *AerospikeKeyOrderedDict_Ready()
 {

--- a/src/main/key_ordered_dict/type.c
+++ b/src/main/key_ordered_dict/type.c
@@ -32,7 +32,7 @@ static PyMethodDef AerospikeKeyOrderedDict_Type_Methods[] = {{NULL}};
 static int AerospikeKeyOrderedDict_Type_Init(PyObject *self, PyObject *args,
                                              PyObject *kwds)
 {
-    return PyDict_Type.tp_init((PyObject *)self, args, kwds);
+    return PyDict_Type.tp_init(self, args, kwds);
 }
 
 /*******************************************************************************

--- a/src/main/key_ordered_dict/type.c
+++ b/src/main/key_ordered_dict/type.c
@@ -25,6 +25,14 @@
 
 static PyMethodDef AerospikeKeyOrderedDict_Type_Methods[] = {{NULL}};
 
+static int local_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    AerospikeKeyOrderedDict *self_keyordereddict =
+        (AerospikeKeyOrderedDict *)self;
+    Py_VISIT(&self_keyordereddict->dict);
+    return 0;
+}
+
 /*******************************************************************************
  * PYTHON TYPE HOOKS
  ******************************************************************************/
@@ -39,16 +47,19 @@ static int AerospikeKeyOrderedDict_Type_Init(PyObject *self, PyObject *args,
  * PYTHON TYPE DESCRIPTOR
  ******************************************************************************/
 
-static PyTypeObject AerospikeKeyOrderedDict_Type = {
-    PyVarObject_HEAD_INIT(NULL, 0).tp_name = "aerospike.KeyOrderedDict",
-    .tp_basicsize = sizeof(AerospikeKeyOrderedDict),
-    .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
-    .tp_doc = "The KeyOrderedDict class is a dictionary that directly maps\n"
-              "to a key ordered map on the Aerospike server.\n"
-              "This assists in matching key ordered maps\n"
-              "through various read operations.\n",
-    .tp_methods = AerospikeKeyOrderedDict_Type_Methods,
-    .tp_init = (initproc)AerospikeKeyOrderedDict_Type_Init};
+static PyTypeObject
+    AerospikeKeyOrderedDict_Type =
+        {PyVarObject_HEAD_INIT(NULL, 0).tp_name = "aerospike.KeyOrderedDict",
+         .tp_basicsize = sizeof(AerospikeKeyOrderedDict),
+         .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+         .tp_doc =
+             "The KeyOrderedDict class is a dictionary that directly maps\n"
+             "to a key ordered map on the Aerospike server.\n"
+             "This assists in matching key ordered maps\n"
+             "through various read operations.\n",
+         .tp_methods = AerospikeKeyOrderedDict_Type_Methods,
+         .tp_init = (initproc)AerospikeKeyOrderedDict_Type_Init},
+    .tp_traverse = local_traverse;
 
 PyTypeObject *AerospikeKeyOrderedDict_Ready()
 {

--- a/src/main/key_ordered_dict/type.c
+++ b/src/main/key_ordered_dict/type.c
@@ -47,19 +47,17 @@ static int AerospikeKeyOrderedDict_Type_Init(PyObject *self, PyObject *args,
  * PYTHON TYPE DESCRIPTOR
  ******************************************************************************/
 
-static PyTypeObject
-    AerospikeKeyOrderedDict_Type =
-        {PyVarObject_HEAD_INIT(NULL, 0).tp_name = "aerospike.KeyOrderedDict",
-         .tp_basicsize = sizeof(AerospikeKeyOrderedDict),
-         .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
-         .tp_doc =
-             "The KeyOrderedDict class is a dictionary that directly maps\n"
-             "to a key ordered map on the Aerospike server.\n"
-             "This assists in matching key ordered maps\n"
-             "through various read operations.\n",
-         .tp_methods = AerospikeKeyOrderedDict_Type_Methods,
-         .tp_init = (initproc)AerospikeKeyOrderedDict_Type_Init},
-    .tp_traverse = local_traverse;
+static PyTypeObject AerospikeKeyOrderedDict_Type = {
+    PyVarObject_HEAD_INIT(NULL, 0).tp_name = "aerospike.KeyOrderedDict",
+    .tp_basicsize = sizeof(AerospikeKeyOrderedDict),
+    .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+    .tp_doc = "The KeyOrderedDict class is a dictionary that directly maps\n"
+              "to a key ordered map on the Aerospike server.\n"
+              "This assists in matching key ordered maps\n"
+              "through various read operations.\n",
+    .tp_methods = AerospikeKeyOrderedDict_Type_Methods,
+    .tp_init = (initproc)AerospikeKeyOrderedDict_Type_Init,
+    .tp_traverse = local_traverse};
 
 PyTypeObject *AerospikeKeyOrderedDict_Ready()
 {

--- a/src/main/key_ordered_dict/type.c
+++ b/src/main/key_ordered_dict/type.c
@@ -29,8 +29,8 @@ static PyMethodDef AerospikeKeyOrderedDict_Type_Methods[] = {{NULL}};
  * PYTHON TYPE HOOKS
  ******************************************************************************/
 
-static int AerospikeKeyOrderedDict_Type_Init(AerospikeQuery *self,
-                                             PyObject *args, PyObject *kwds)
+static int AerospikeKeyOrderedDict_Type_Init(PyObject *self, PyObject *args,
+                                             PyObject *kwds)
 {
     return PyDict_Type.tp_init((PyObject *)self, args, kwds);
 }

--- a/test/new_tests/test_get_put_keyordereddict.py
+++ b/test/new_tests/test_get_put_keyordereddict.py
@@ -1,0 +1,19 @@
+from aerospike import KeyOrderedDict
+import pytest
+
+
+class TestGetPutOrderedDict:
+    @pytest.fixture(autouse=True)
+    def setup(self, request, as_connection):
+        pass
+
+    def test_get_put_keyordereddict(self):
+        bins = {
+            "dict": KeyOrderedDict({"f": 6, "e": 5, "d": 4})
+        }
+        key = ("test", "demo", 1)
+        self.as_connection.put(key, bins)
+
+        _, _, res = self.as_connection.get(key)
+        assert res["dict"] == KeyOrderedDict({"f": 6, "e": 5, "d": 4})
+        assert type(res["dict"]) == KeyOrderedDict

--- a/test/new_tests/test_get_put_keyordereddict.py
+++ b/test/new_tests/test_get_put_keyordereddict.py
@@ -1,19 +1,24 @@
 from aerospike import KeyOrderedDict
 import pytest
+from aerospike import exception as e
 
 
 class TestGetPutOrderedDict:
     @pytest.fixture(autouse=True)
     def setup(self, request, as_connection):
-        pass
+        yield
+        try:
+            self.as_connection.remove(self.key)
+        except e.AerospikeError:
+            pass
 
     def test_get_put_keyordereddict(self):
         bins = {
             "dict": KeyOrderedDict({"f": 6, "e": 5, "d": 4})
         }
-        key = ("test", "demo", 1)
-        self.as_connection.put(key, bins)
+        self.key = ("test", "demo", 1)
+        self.as_connection.put(self.key, bins)
 
-        _, _, res = self.as_connection.get(key)
+        _, _, res = self.as_connection.get(self.key)
         assert res["dict"] == KeyOrderedDict({"f": 6, "e": 5, "d": 4})
         assert type(res["dict"]) == KeyOrderedDict

--- a/test/new_tests/test_get_put_keyordereddict.py
+++ b/test/new_tests/test_get_put_keyordereddict.py
@@ -12,13 +12,30 @@ class TestGetPutOrderedDict:
         except e.AerospikeError:
             pass
 
-    def test_get_put_keyordereddict(self):
+    @pytest.mark.parametrize(
+        "bin_value",
+        [
+            KeyOrderedDict({"f": 6, "e": 5, "d": 4}),
+            [
+                KeyOrderedDict({"f": 6, "e": 5, "d": 4})
+            ]
+        ],
+        ids=[
+            "bin-level",
+            "nested"
+        ]
+    )
+    def test_get_put_keyordereddict(self, bin_value):
         bins = {
-            "dict": KeyOrderedDict({"f": 6, "e": 5, "d": 4})
+            "dict": bin_value
         }
         self.key = ("test", "demo", 1)
         self.as_connection.put(self.key, bins)
 
         _, _, res = self.as_connection.get(self.key)
-        assert res["dict"] == KeyOrderedDict({"f": 6, "e": 5, "d": 4})
-        assert type(res["dict"]) == KeyOrderedDict
+
+        assert res["dict"] == bin_value
+        if type(res["dict"]) == list:
+            assert type(res["dict"][0]) == KeyOrderedDict
+        else:
+            assert type(res["dict"]) == KeyOrderedDict


### PR DESCRIPTION
Valgrind (no memory errors or leaks from PR): https://github.com/aerospike/aerospike-client-python/actions/runs/7996974797
Build wheels: https://github.com/aerospike/aerospike-client-python/actions/runs/7997568091