### PR TITLE
[CLIENT-2654] Remove Debian 10 support

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -354,7 +354,6 @@ jobs:
       strategy:
         matrix:
           debian-name: [
-            "buster",
             "bookworm"
           ]
       container:

--- a/BUILD.md
+++ b/BUILD.md
@@ -35,7 +35,7 @@ sudo yum install python-setuptools
 
 The following are dependencies for:
 
-- Debian 10 or newer
+- Debian 11 or newer
 - Ubuntu 20.04 or newer
 - Related distributions which use the `apt` package manager
 

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ The Python client for Aerospike works with Python 3.8 - 3.11 and supports the fo
 * CentOS 7 Linux
 * RHEL 8 and 9
 * Amazon Linux 2023
-* Debian 10, 11, and 12
+* Debian 11 and 12
 * Ubuntu 20.04 and 22.04
 
 The client is also verified to run on these operating systems, but we do not officially support them (i.e we don't distribute wheels or prioritize fixing bugs for these OSes):


### PR DESCRIPTION
Build wheels workflow still works: https://github.com/aerospike/aerospike-client-python/actions/runs/6776927253