### PR TITLE
CLIENT-2383

### DIFF
--- a/src/main/conversions.c
+++ b/src/main/conversions.c
@@ -2382,7 +2382,15 @@ as_status get_cdt_ctx(AerospikeClient *self, as_error *err, as_cdt_ctx *cdt_ctx,
                       PyObject *op_dict, bool *ctx_in_use,
                       as_static_pool *static_pool, int serializer_type)
 {
-    PyObject *py_ctx = PyDict_GetItemString(op_dict, CTX_KEY);
+    PyObject *py_ctx = NULL;
+    if(PyDict_Check(op_dict)){
+        py_ctx = PyDict_GetItemString(op_dict, CTX_KEY);        
+    }
+    else{
+        py_ctx = op_dict;
+    }
+
+    
     long int_val = 0;
     as_val *val = NULL;
 

--- a/test/new_tests/test_base_class.py
+++ b/test/new_tests/test_base_class.py
@@ -178,9 +178,9 @@ class TestBaseClass(object):
                 if res is not None:
                     break
             res = res.split(".")
-            # major_ver = res[0]
-            # minor_ver = res[1]
-            # print("major_ver:", major_ver, "minor_ver:", minor_ver)
+            TestBaseClass.major_ver = res[0]
+            TestBaseClass.minor_ver = res[1]
+            # print("major_ver:", TestBaseClass.major_ver, "minor_ver:", TestBaseClass.minor_ver)
 
         return client
 

--- a/test/new_tests/test_cdt_index.py
+++ b/test/new_tests/test_cdt_index.py
@@ -103,7 +103,7 @@ class TestCDTIndex(object):
             aerospike.INDEX_TYPE_LIST,
             aerospike.INDEX_STRING,
             "test_string_list_cdt_index",
-            {"ctx": ctx_list_index},
+            ctx_list_index,
             policy,
         )
 
@@ -148,7 +148,7 @@ class TestCDTIndex(object):
             aerospike.INDEX_TYPE_LIST,
             aerospike.INDEX_STRING,
             "test_string_list_cdt_index",
-            {"ctx": ctx_list_rank},
+            ctx_list_rank,
             policy,
         )
 
@@ -169,7 +169,7 @@ class TestCDTIndex(object):
             aerospike.INDEX_TYPE_LIST,
             aerospike.INDEX_STRING,
             "test_string_list_cdt_index",
-            {"ctx": ctx_list_value},
+            ctx_list_value,
             policy,
         )
 
@@ -190,7 +190,7 @@ class TestCDTIndex(object):
             aerospike.INDEX_TYPE_MAPKEYS,
             aerospike.INDEX_STRING,
             "test_string_list_cdt_index",
-            {"ctx": ctx_map_index},
+            ctx_map_index,
             policy,
         )
 
@@ -211,7 +211,7 @@ class TestCDTIndex(object):
             aerospike.INDEX_TYPE_MAPVALUES,
             aerospike.INDEX_STRING,
             "test_string_list_cdt_index",
-            {"ctx": ctx_map_value},
+            ctx_map_value,
             policy,
         )
 
@@ -232,7 +232,7 @@ class TestCDTIndex(object):
             aerospike.INDEX_TYPE_MAPVALUES,
             aerospike.INDEX_STRING,
             "test_string_list_cdt_index",
-            {"ctx": ctx_map_rank},
+            ctx_map_rank,
             policy,
         )
 
@@ -254,7 +254,7 @@ class TestCDTIndex(object):
             aerospike.INDEX_TYPE_MAPVALUES,
             aerospike.INDEX_STRING,
             "test_string_list_cdt_index",
-            {"ctx": ctx_map_rank},
+            ctx_map_rank,
             policy,
         )
 
@@ -275,7 +275,7 @@ class TestCDTIndex(object):
             aerospike.INDEX_TYPE_LIST,
             aerospike.INDEX_NUMERIC,
             "test_numeric_list_cdt_index",
-            {"ctx": ctx_list_index},
+            ctx_list_index,
             policy,
         )
 
@@ -298,7 +298,7 @@ class TestCDTIndex(object):
                 aerospike.INDEX_TYPE_LIST,
                 aerospike.INDEX_STRING,
                 "test_string_list_cdt_index",
-                {"ctx": ctx_list_index},
+                ctx_list_index,
                 policy,
             )
             assert False
@@ -319,7 +319,7 @@ class TestCDTIndex(object):
             aerospike.INDEX_TYPE_LIST,
             aerospike.INDEX_STRING,
             "test_string_list_cdt_index",
-            {"ctx": ctx_list_index},
+            ctx_list_index,
             policy,
         )
 
@@ -339,7 +339,7 @@ class TestCDTIndex(object):
             aerospike.INDEX_TYPE_LIST,
             aerospike.INDEX_NUMERIC,
             "test_numeric_list_cdt_index",
-            {"ctx": ctx_list_index},
+            ctx_list_index,
             policy,
         )
         if retobj == 0:
@@ -351,7 +351,7 @@ class TestCDTIndex(object):
                     aerospike.INDEX_TYPE_LIST,
                     aerospike.INDEX_NUMERIC,
                     "test_numeric_list_cdt_index",
-                    {"ctx": ctx_list_index},
+                    ctx_list_index,
                     policy,
                 )
             except e.IndexFoundError:
@@ -373,7 +373,7 @@ class TestCDTIndex(object):
             aerospike.INDEX_TYPE_LIST,
             aerospike.INDEX_STRING,
             "test_string_list_cdt_index",
-            {"ctx": ctx_list_index},
+            ctx_list_index,
             policy,
         )
         if retobj == 0:
@@ -385,7 +385,7 @@ class TestCDTIndex(object):
                     aerospike.INDEX_TYPE_LIST,
                     aerospike.INDEX_NUMERIC,
                     "test_string_list_cdt_index",
-                    {"ctx": ctx_list_index},
+                    ctx_list_index,
                     policy,
                 )
                 self.as_connection.index_remove("test", "test_string_list_cdt_index", policy)
@@ -409,7 +409,7 @@ class TestCDTIndex(object):
             aerospike.INDEX_TYPE_LIST,
             aerospike.INDEX_STRING,
             "test_string_list_cdt_index",
-            {"ctx": ctx_list_index},
+            ctx_list_index,
             policy,
         )
         if retobj == 0:
@@ -421,7 +421,7 @@ class TestCDTIndex(object):
                     aerospike.INDEX_TYPE_LIST,
                     aerospike.INDEX_STRING,
                     "test_string_list_cdt_index1",
-                    {"ctx": ctx_list_index},
+                    ctx_list_index,
                     policy,
                 )
             except e.IndexFoundError:
@@ -444,7 +444,7 @@ class TestCDTIndex(object):
             aerospike.INDEX_TYPE_LIST,
             aerospike.INDEX_NUMERIC,
             "test_numeric_list_cdt_index_pol",
-            {"ctx": ctx_list_index},
+            ctx_list_index,
             policy,
         )
 
@@ -464,7 +464,7 @@ class TestCDTIndex(object):
             aerospike.INDEX_TYPE_LIST,
             aerospike.INDEX_STRING,
             "test_string_list_cdt_index",
-            {"ctx": ctx_list_index},
+            ctx_list_index,
             policy,
         )
 
@@ -501,7 +501,7 @@ cfasdcalskdcbacfq34915rwcfasdcascnabscbaskjdbcalsjkbcdasc');
             aerospike.INDEX_TYPE_LIST,
             aerospike.INDEX_STRING,
             "uni_name_index",
-            {"ctx": ctx_list_index},
+            ctx_list_index,
             policy,
         )
 
@@ -521,7 +521,7 @@ cfasdcalskdcbacfq34915rwcfasdcascnabscbaskjdbcalsjkbcdasc');
             aerospike.INDEX_TYPE_LIST,
             aerospike.INDEX_NUMERIC,
             "uni_age_index",
-            {"ctx": ctx_list_index},
+            ctx_list_index,
             policy,
         )
 
@@ -557,7 +557,7 @@ cfasdcalskdcbacfq34915rwcfasdcascnabscbaskjdbcalsjkbcdasc');
                 aerospike.INDEX_TYPE_LIST,
                 aerospike.INDEX_STRING,
                 "test_string_list_cdt_index",
-                {"ctx": ctx_list_index},
+                ctx_list_index,
                 policy,
             )
 
@@ -578,7 +578,7 @@ cfasdcalskdcbacfq34915rwcfasdcascnabscbaskjdbcalsjkbcdasc');
                 aerospike.INDEX_TYPE_LIST,
                 aerospike.INDEX_STRING,
                 "test_string_list_cdt_index",
-                {"ctx": ctx_list_index},
+                ctx_list_index,
                 policy,
             )
             assert False
@@ -601,7 +601,7 @@ cfasdcalskdcbacfq34915rwcfasdcascnabscbaskjdbcalsjkbcdasc');
                 aerospike.INDEX_TYPE_LIST,
                 aerospike.INDEX_STRING,
                 "test_string_list_cdt_index",
-                {"ctx": ctx_list_index},
+                ctx_list_index,
                 policy,
             )
 
@@ -624,7 +624,7 @@ cfasdcalskdcbacfq34915rwcfasdcascnabscbaskjdbcalsjkbcdasc');
                 aerospike.INDEX_TYPE_LIST,
                 aerospike.INDEX_NUMERIC,
                 "test_numeric_list_cdt_index",
-                {"ctx": ctx_list_index},
+                ctx_list_index,
                 policy,
             )
 
@@ -645,7 +645,7 @@ cfasdcalskdcbacfq34915rwcfasdcascnabscbaskjdbcalsjkbcdasc');
                 aerospike.INDEX_TYPE_LIST,
                 aerospike.INDEX_STRING,
                 None,
-                {"ctx": ctx_list_index},
+                ctx_list_index,
                 policy,
             )
 
@@ -667,7 +667,7 @@ cfasdcalskdcbacfq34915rwcfasdcascnabscbaskjdbcalsjkbcdasc');
                 aerospike.INDEX_TYPE_DEFAULT,
                 aerospike.INDEX_NUMERIC,
                 "test_numeric_list_cdt_index",
-                {"ctx": ctx_list_index},
+                ctx_list_index,
                 policy,
             )
 
@@ -686,7 +686,7 @@ cfasdcalskdcbacfq34915rwcfasdcascnabscbaskjdbcalsjkbcdasc');
             aerospike.INDEX_TYPE_LIST,
             aerospike.INDEX_NUMERIC,
             "test_numeric_list_cdt_index",
-            {"ctx": ctx_list_index},
+            ctx_list_index,
             policy,
         )
 
@@ -711,7 +711,7 @@ cfasdcalskdcbacfq34915rwcfasdcascnabscbaskjdbcalsjkbcdasc');
                 aerospike.INDEX_TYPE_LIST,
                 aerospike.INDEX_STRING,
                 "test_string_list_cdt_index",
-                {"ctx": ctx_list_index},
+                ctx_list_index,
                 policy,
             )
 

--- a/test/new_tests/test_query.py
+++ b/test/new_tests/test_query.py
@@ -120,7 +120,7 @@ class TestQuery(TestBaseClass):
         except e.IndexFoundError:
             pass
 
-        if (TestBaseClass.major_ver, TestBaseClass.minor_ver) >= (7, 0):
+        if (int(TestBaseClass.major_ver), int(TestBaseClass.minor_ver)) >= (7, 0):
             # These indexes are only used for server 7.0+ tests
             try:
                 client.index_list_create("test", "demo", "blob_list", aerospike.INDEX_BLOB, "blob_list_index")
@@ -147,7 +147,7 @@ class TestQuery(TestBaseClass):
                 aerospike.INDEX_TYPE_DEFAULT,
                 aerospike.INDEX_NUMERIC,
                 "numeric_list_cdt_index",
-                {"ctx": ctx_list_index},
+                ctx_list_index,
             )
         except e.IndexFoundError:
             pass
@@ -160,7 +160,7 @@ class TestQuery(TestBaseClass):
                 aerospike.INDEX_TYPE_DEFAULT,
                 aerospike.INDEX_NUMERIC,
                 "numeric_map_cdt_index",
-                {"ctx": ctx_map_index},
+                ctx_map_index,
             )
         except e.IndexFoundError:
             pass


### PR DESCRIPTION
CLIENT-2383
Added support for context lists in Client.index_cdt_create() and Client.Query.where() Fixed the check for TestBaseClass.version not working corerctly upon initialization