### PR TITLE
[CLIENT-2742] CI/CD: Use larger runners for macOS x86 tests

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -427,7 +427,7 @@ jobs:
           ["cp310", "3.10"],
           ["cp311", "3.11"]
         ]
-        os: [macos-latest]
+        os: [macos-12-large]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Build wheels runs:
1. https://github.com/aerospike/aerospike-client-python/actions/runs/7453600256
2. https://github.com/aerospike/aerospike-client-python/actions/runs/7453599302
3. https://github.com/aerospike/aerospike-client-python/actions/runs/7453580753

Only 1/24 tests failed, which is a better result than what we currently are getting. About half of the time, colima fails to let us connect to a Docker container.