### PR TITLE
[CLIENT-1837] CI/CD: Fix minor issues and make improvements to pipeline

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -426,7 +426,7 @@ jobs:
           CIBW_BEFORE_BUILD_WINDOWS: "pip install delvewheel"
           CIBW_REPAIR_WHEEL_COMMAND: "delvewheel repair --add-path ./aerospike-client-c/vs/x64/Release -w {dest_dir} {wheel}"
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
           name: ${{ matrix.python[0] }}-win_amd64.build

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -396,6 +396,7 @@ jobs:
           ["cp39", "3.9"],
           ["cp310", "3.10"],
           ["cp311", "3.11"],
+          ["cp312", "3.12"]
         ]
     runs-on: windows-2022
     steps:
@@ -418,7 +419,7 @@ jobs:
         working-directory: aerospike-client-c/vs
 
       - name: Build wheel
-        uses: pypa/cibuildwheel@v2.11.2
+        uses: pypa/cibuildwheel@v2.15.0
         env:
           CIBW_BUILD: ${{ matrix.python[0] }}-win_amd64
           CIBW_BUILD_FRONTEND: build
@@ -450,6 +451,7 @@ jobs:
           ["cp39", "3.9"],
           ["cp310", "3.10"],
           ["cp311", "3.11"],
+          ["cp312", "3.12"]
         ]
     runs-on: [self-hosted, Windows, X64]
     steps:

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -175,7 +175,7 @@ jobs:
       run: echo "UNOPTIMIZED=1" >> $GITHUB_ENV
 
     - name: Build wheel
-      uses: pypa/cibuildwheel@v2.15.0
+      uses: pypa/cibuildwheel@v2.16.5
       env:
         CIBW_ENVIRONMENT_PASS_LINUX: ${{ inputs.build-for-debugging && 'UNOPTIMIZED' || '' }}
         CIBW_BUILD: ${{ matrix.python }}-manylinux_${{ matrix.platform }}
@@ -254,7 +254,7 @@ jobs:
       run: echo "TEST_COMMAND=python -c 'import aerospike'" >> $GITHUB_ENV
 
     - name: Build wheel
-      uses: pypa/cibuildwheel@v2.15.0
+      uses: pypa/cibuildwheel@v2.16.5
       env:
         CIBW_BUILD: ${{ matrix.python }}-macosx_x86_64
         CIBW_BUILD_FRONTEND: build
@@ -419,7 +419,7 @@ jobs:
         working-directory: aerospike-client-c/vs
 
       - name: Build wheel
-        uses: pypa/cibuildwheel@v2.15.0
+        uses: pypa/cibuildwheel@v2.16.5
         env:
           CIBW_BUILD: ${{ matrix.python[0] }}-win_amd64
           CIBW_BUILD_FRONTEND: build

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -466,7 +466,7 @@ jobs:
 
       - run: docker run -d -p 3000:3000 --name aerospike aerospike/aerospike-server
       - name: Download wheel
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ matrix.python[0] }}-win_amd64.build
       - name: Install wheel

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -408,6 +408,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+          ref: ${{ inputs.ref }}
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.1
@@ -458,6 +459,9 @@ jobs:
           sha: ${{ github.sha }}
           context: "Test Windows (${{ matrix.python[0] }}-win_amd64)"
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
       - run: docker run -d -p 3000:3000 --name aerospike aerospike/aerospike-server
       - name: Download wheel
         uses: actions/download-artifact@v3

--- a/.github/workflows/dev-workflow-p1.yml
+++ b/.github/workflows/dev-workflow-p1.yml
@@ -9,7 +9,7 @@ on:
     types:
       - review_requested
     branches:
-      - dev*
+      - 'dev*'
   # So we can test changes to the test-server-rc workflow
   workflow_dispatch:
     inputs:

--- a/.github/workflows/dev-workflow-p2.yml
+++ b/.github/workflows/dev-workflow-p2.yml
@@ -6,10 +6,11 @@ on:
     - 'dev*'
     types:
       - closed
+  workflow_dispatch:
 
 jobs:
   bump-dev-number:
-    if: ${{ github.event.pull_request.merged == true }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}
     uses: ./.github/workflows/bump-version.yml
     with:
       change: 'bump-dev-num'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,8 @@ env:
 on:
   push:
     branches: ["dev", "stage", "master", "v*-backport"]
+    # Ignore all bump commits
+    tags-ignore: ["*"]
   pull_request:
     branches: ["dev", "stage", "v*-backport"]
     types: [

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ on:
   push:
     branches: ["dev*", "stage*", "master*", "v*-backport*"]
     # Ignore all bump commits
-    tags-ignore: ["*"]
+    tags-ignore: ["**"]
   pull_request:
     branches: ["dev*", "stage*", "v*-backport*"]
     types: [

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,11 +8,11 @@ env:
 # 2. Commits are pushed directly to the dev, stage or master branch
 on:
   push:
-    branches: ["dev", "stage", "master", "v*-backport"]
+    branches: ["dev*", "stage*", "master*", "v*-backport*"]
     # Ignore all bump commits
     tags-ignore: ["*"]
   pull_request:
-    branches: ["dev", "stage", "v*-backport"]
+    branches: ["dev*", "stage*", "v*-backport*"]
     types: [
       # Default triggers
       opened,

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,8 +9,6 @@ env:
 on:
   push:
     branches: ["dev*", "stage*", "master*", "v*-backport*"]
-    # Ignore all bump commits
-    tags-ignore: ["**"]
   pull_request:
     branches: ["dev*", "stage*", "v*-backport*"]
     types: [

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: PR pre-merge tests
+name: PR tests
 
 env:
   LOWEST_SUPPORTED_PY_VERSION: '3.8'

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -53,7 +53,7 @@ jobs:
     - name: Commit new version
       uses: stefanzweifel/git-auto-commit-action@v4
       with:
-        commit_message: Auto-bump version to ${{ inputs.new_version }}
+        commit_message: 'Auto-bump version to ${{ inputs.new_version }} [skip ci]'
         commit_author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
         tagging_message: ${{ inputs.new_version }}
         branch: ${{ inputs.is_workflow_call && inputs.ref || github.ref }}


### PR DESCRIPTION
Improvements:
- Update cibuildwheel version to v2.16.5
- Add option to run dev-workflow-p2 workflow manually
- Rename PR pre-merge tests workflow to "PR tests"
- Skip PR tests on bump commits
- Run PR tests on mock branches (i.e dev-test)

Fixes:
- Build Windows x86 Python 3.12 wheel
- Fix checking out the wrong commit for windows builds and tests
- Fix Windows wheels not being uploaded to JFrog
- Fix dev-workflow-p1 workflow not running when review is requested on a PR

Testing

Bump commits skip CI/CD workflow: https://github.com/aerospike/aerospike-client-python/commits/dev-test/
Windows wheels including Python 3.12 successfully uploaded to JFrog: https://github.com/aerospike/aerospike-client-python/actions/runs/7995790908/job/21837350699