### PR TITLE
[CLIENT-2444] Docs: Add note about POLICY_KEY_SEND and list possible map key types

### DIFF
--- a/doc/aerospike.rst
+++ b/doc/aerospike.rst
@@ -807,7 +807,10 @@ Specifies the behavior for whether keys or digests should be sent to the cluster
 
 .. data:: POLICY_KEY_SEND
 
-    Send the key in addition to the digest. This policy causes a write operation to store the key on the server
+    Send the key in addition to the digest. This policy causes a write operation to store the key on the server.
+
+    .. note:: This option instructs the server to validate the digest by calculating it again from the key sent by the
+        client. Unless this is the explicit intent of the developer, this should be avoided.
 
 .. _POLICY_REPLICA:
 

--- a/doc/data_mapping.rst
+++ b/doc/data_mapping.rst
@@ -62,6 +62,8 @@ The following table shows which Python types map directly to Aerospike server ty
   :class:`aerospike_helpers.HyperLogLog`   `HyperLogLog`_
  ======================================== =========================
 
+For server 7.1 and higher, map keys can only be of type string, bytes, and integer.
+
 .. note::
 
     :ref:`KeyOrderedDict <aerospike.KeyOrderedDict>` is a special case. Like :class:`dict`, :class:`~aerospike.KeyOrderedDict` maps to the Aerospike map data type. \
@@ -69,10 +71,6 @@ The following table shows which Python types map directly to Aerospike server ty
 
 It is possible to nest these datatypes. For example a list may contain a dictionary, or a dictionary may contain a list
 as a value.
-
-.. note::
-
-    For server 7.1 and higher, map keys can only be of type string, bytes, and integer.
 
 .. _integer: https://aerospike.com/docs/server/guide/data-types/scalar-data-types#integer
 .. _string: https://aerospike.com/docs/server/guide/data-types/scalar-data-types#string

--- a/doc/data_mapping.rst
+++ b/doc/data_mapping.rst
@@ -70,6 +70,10 @@ The following table shows which Python types map directly to Aerospike server ty
 It is possible to nest these datatypes. For example a list may contain a dictionary, or a dictionary may contain a list
 as a value.
 
+.. note::
+
+    For server 7.1 and higher, map keys can only be of type string, bytes, and integer.
+
 .. _integer: https://aerospike.com/docs/server/guide/data-types/scalar-data-types#integer
 .. _string: https://aerospike.com/docs/server/guide/data-types/scalar-data-types#string
 .. _double: https://aerospike.com/docs/server/guide/data-types/scalar-data-types#double

--- a/test/new_tests/test_expressions_map.py
+++ b/test/new_tests/test_expressions_map.py
@@ -202,7 +202,7 @@ class TestExpressions(TestBaseClass):
                 "bymap_bin": {1: "b".encode("utf8"), 2: "d".encode("utf8"), 3: "f".encode("utf8")},
                 "bomap_bin": {1: False, 2: False, 3: True},
                 "nmap_bin": {1: None, 2: aerospike.null(), 3: aerospike.null()},
-                "fmap_bin": {1.0: 1.0, 2.0: 2.0, 6.0: 6.0},
+                "fmap_bin": {1: 1.0, 2: 2.0, 6: 6.0},
                 "gmap_bin": {1: GEO_POLY, 2: GEO_POLY1, 3: GEO_POLY2},
             }
             self.as_connection.put(key, rec)
@@ -413,7 +413,7 @@ class TestExpressions(TestBaseClass):
         "bin, bin_name, ctx, policy, key, value, expected",
         [
             ("imap_bin", "imap_bin", None, None, 3, 6, [12]),
-            ("fmap_bin", "fmap_bin", None, None, 6.0, 6.0, [12.0]),
+            ("fmap_bin", "fmap_bin", None, None, 6, 6.0, [12.0]),
             (ListBin("mlist_bin"), "mlist_bin", [cdt_ctx.cdt_ctx_list_index(0)], None, 1, 4, [6]),
         ],
     )
@@ -471,7 +471,7 @@ class TestExpressions(TestBaseClass):
                 "fmap_bin",
                 None,
                 {},
-                [8.0, 10.0, 1.0, 1.0, 6.0, 6.0],
+                [8, 10.0, 1, 1.0, 6, 6.0],
             ),
         ],
     )
@@ -773,8 +773,8 @@ class TestExpressions(TestBaseClass):
                 ),
                 [2, 1]
             ),
-            # Get entries with keys 2.0 and 6.0
-            # Inverse is entry with key 1.0
+            # Get entries with keys 2 and 6
+            # Inverse is entry with key 1
             # This has reverse rank 2
             (
                 "fmap_bin",

--- a/test/new_tests/test_geospatial.py
+++ b/test/new_tests/test_geospatial.py
@@ -62,12 +62,13 @@ def add_geo_indexes(connection):
     except (e.IndexFoundError):
         pass
 
-    try:
-        connection.index_map_keys_create(
-            "test", "demo", "geo_loc_mk", aerospike.INDEX_GEO2DSPHERE, "geo_loc_map_key_index"
-        )
-    except (e.IndexFoundError):
-        pass
+    if (TestBaseClass.major_ver, TestBaseClass.minor_ver) < (7, 1):
+        try:
+            connection.index_map_keys_create(
+                "test", "demo", "geo_loc_mk", aerospike.INDEX_GEO2DSPHERE, "geo_loc_map_key_index"
+            )
+        except (e.IndexFoundError):
+            pass
 
     try:
         connection.index_map_values_create(
@@ -109,17 +110,24 @@ def add_geo_data(connection):
     )
 
     geo_loc_list = [geo_object_polygon]
-    geo_loc_mk = {geo_object_polygon: 1}
     geo_loc_mv = {2: geo_object_polygon}
     connection.put(
         key,
         {
             "loc_polygon": geo_object_polygon,
             "geo_loc_list": geo_loc_list,
-            "geo_loc_mk": geo_loc_mk,
             "geo_loc_mv": geo_loc_mv,
         },
     )
+
+    if (TestBaseClass.major_ver, TestBaseClass.minor_ver) < (7, 1):
+        geo_loc_mk = {geo_object_polygon: 1}
+        connection.put(
+            key,
+            {
+                "geo_loc_mk": geo_loc_mk,
+            },
+        )
 
     key = ("test", "demo", "polygon2")
     geo_object_polygon = aerospike.GeoJSON(
@@ -138,17 +146,23 @@ def add_geo_data(connection):
     )
 
     geo_loc_list = [geo_object_polygon]
-    geo_loc_mk = {geo_object_polygon: 1}
     geo_loc_mv = {2: geo_object_polygon}
     connection.put(
         key,
         {
             "loc_polygon": geo_object_polygon,
             "geo_loc_list": geo_loc_list,
-            "geo_loc_mk": geo_loc_mk,
             "geo_loc_mv": geo_loc_mv,
         },
     )
+    if (TestBaseClass.major_ver, TestBaseClass.minor_ver) < (7, 1):
+        geo_loc_mk = {geo_object_polygon: 1}
+        connection.put(
+            key,
+            {
+                "geo_loc_mk": geo_loc_mk,
+            },
+        )
 
 
 def remove_geo_indexes(connection):
@@ -1071,6 +1085,8 @@ class TestGeospatial(object):
         ),
     )
     def test_geospatial_contains_point_pred(self, bin_name, idx_type):
+        if bin_name == "geo_loc_mk" and (TestBaseClass.major_ver, TestBaseClass.minor_ver) >= (7, 1):
+            pytest.skip("GeoJSON map keys are no longer supported in server 7.1 and higher")
 
         records = []
         query = self.as_connection.query("test", "demo")
@@ -1097,6 +1113,8 @@ class TestGeospatial(object):
         ),
     )
     def test_geospatial_contains_json_point_pred(self, bin_name, idx_type):
+        if bin_name == "geo_loc_mk" and (TestBaseClass.major_ver, TestBaseClass.minor_ver) >= (7, 1):
+            pytest.skip("GeoJSON map keys are no longer supported in server 7.1 and higher")
 
         records = []
         query = self.as_connection.query("test", "demo")

--- a/test/new_tests/test_geospatial.py
+++ b/test/new_tests/test_geospatial.py
@@ -63,13 +63,6 @@ def add_geo_indexes(connection):
         pass
 
     try:
-        connection.index_map_keys_create(
-            "test", "demo", "geo_loc_mk", aerospike.INDEX_GEO2DSPHERE, "geo_loc_map_key_index"
-        )
-    except (e.IndexFoundError):
-        pass
-
-    try:
         connection.index_map_values_create(
             "test", "demo", "geo_loc_mv", aerospike.INDEX_GEO2DSPHERE, "geo_loc_map_val_index"
         )
@@ -109,14 +102,12 @@ def add_geo_data(connection):
     )
 
     geo_loc_list = [geo_object_polygon]
-    geo_loc_mk = {geo_object_polygon: 1}
     geo_loc_mv = {2: geo_object_polygon}
     connection.put(
         key,
         {
             "loc_polygon": geo_object_polygon,
             "geo_loc_list": geo_loc_list,
-            "geo_loc_mk": geo_loc_mk,
             "geo_loc_mv": geo_loc_mv,
         },
     )
@@ -138,14 +129,12 @@ def add_geo_data(connection):
     )
 
     geo_loc_list = [geo_object_polygon]
-    geo_loc_mk = {geo_object_polygon: 1}
     geo_loc_mv = {2: geo_object_polygon}
     connection.put(
         key,
         {
             "loc_polygon": geo_object_polygon,
             "geo_loc_list": geo_loc_list,
-            "geo_loc_mk": geo_loc_mk,
             "geo_loc_mv": geo_loc_mv,
         },
     )
@@ -179,11 +168,6 @@ def remove_geo_indexes(connection):
 
     try:
         connection.index_remove("test", "geo_loc_list_index")
-    except Exception:
-        pass
-
-    try:
-        connection.index_remove("test", "geo_loc_map_key_index")
     except Exception:
         pass
 
@@ -1066,7 +1050,6 @@ class TestGeospatial(object):
         "bin_name, idx_type",
         (
             ("geo_loc_list", aerospike.INDEX_TYPE_LIST),
-            ("geo_loc_mk", aerospike.INDEX_TYPE_MAPKEYS),
             ("geo_loc_mv", aerospike.INDEX_TYPE_MAPVALUES),
         ),
     )
@@ -1092,7 +1075,6 @@ class TestGeospatial(object):
         "bin_name, idx_type",
         (
             ("geo_loc_list", aerospike.INDEX_TYPE_LIST),
-            ("geo_loc_mk", aerospike.INDEX_TYPE_MAPKEYS),
             ("geo_loc_mv", aerospike.INDEX_TYPE_MAPVALUES),
         ),
     )

--- a/test/new_tests/test_geospatial.py
+++ b/test/new_tests/test_geospatial.py
@@ -63,6 +63,13 @@ def add_geo_indexes(connection):
         pass
 
     try:
+        connection.index_map_keys_create(
+            "test", "demo", "geo_loc_mk", aerospike.INDEX_GEO2DSPHERE, "geo_loc_map_key_index"
+        )
+    except (e.IndexFoundError):
+        pass
+
+    try:
         connection.index_map_values_create(
             "test", "demo", "geo_loc_mv", aerospike.INDEX_GEO2DSPHERE, "geo_loc_map_val_index"
         )
@@ -102,12 +109,14 @@ def add_geo_data(connection):
     )
 
     geo_loc_list = [geo_object_polygon]
+    geo_loc_mk = {geo_object_polygon: 1}
     geo_loc_mv = {2: geo_object_polygon}
     connection.put(
         key,
         {
             "loc_polygon": geo_object_polygon,
             "geo_loc_list": geo_loc_list,
+            "geo_loc_mk": geo_loc_mk,
             "geo_loc_mv": geo_loc_mv,
         },
     )
@@ -129,12 +138,14 @@ def add_geo_data(connection):
     )
 
     geo_loc_list = [geo_object_polygon]
+    geo_loc_mk = {geo_object_polygon: 1}
     geo_loc_mv = {2: geo_object_polygon}
     connection.put(
         key,
         {
             "loc_polygon": geo_object_polygon,
             "geo_loc_list": geo_loc_list,
+            "geo_loc_mk": geo_loc_mk,
             "geo_loc_mv": geo_loc_mv,
         },
     )
@@ -168,6 +179,11 @@ def remove_geo_indexes(connection):
 
     try:
         connection.index_remove("test", "geo_loc_list_index")
+    except Exception:
+        pass
+
+    try:
+        connection.index_remove("test", "geo_loc_map_key_index")
     except Exception:
         pass
 
@@ -1050,6 +1066,7 @@ class TestGeospatial(object):
         "bin_name, idx_type",
         (
             ("geo_loc_list", aerospike.INDEX_TYPE_LIST),
+            ("geo_loc_mk", aerospike.INDEX_TYPE_MAPKEYS),
             ("geo_loc_mv", aerospike.INDEX_TYPE_MAPVALUES),
         ),
     )
@@ -1075,6 +1092,7 @@ class TestGeospatial(object):
         "bin_name, idx_type",
         (
             ("geo_loc_list", aerospike.INDEX_TYPE_LIST),
+            ("geo_loc_mk", aerospike.INDEX_TYPE_MAPKEYS),
             ("geo_loc_mv", aerospike.INDEX_TYPE_MAPVALUES),
         ),
     )

--- a/test/new_tests/test_geospatial.py
+++ b/test/new_tests/test_geospatial.py
@@ -51,13 +51,6 @@ def add_geo_indexes(connection):
         pass
 
     try:
-        connection.index_map_keys_create(
-            "test", "demo", "geo_map_keys", aerospike.INDEX_GEO2DSPHERE, "geo_map_key_index"
-        )
-    except (e.IndexFoundError):
-        pass
-
-    try:
         connection.index_map_values_create(
             "test", "demo", "geo_map_vals", aerospike.INDEX_GEO2DSPHERE, "geo_map_val_index"
         )
@@ -94,10 +87,9 @@ def add_geo_data(connection):
         s = "{0}: [-{1}.{2}, {3}.{4}{5}".format(pre, (lng // 10), (lng % 10), (lat // 10), (lat % 10), suf)
         geo_object = aerospike.geojson(s)
         geo_list = [geo_object]
-        geo_map_key = {geo_object: i}
         geo_map_val = {i: geo_object}
         connection.put(
-            key, {"loc": geo_object, "geo_list": geo_list, "geo_map_keys": geo_map_key, "geo_map_vals": geo_map_val}
+            key, {"loc": geo_object, "geo_list": geo_list, "geo_map_vals": geo_map_val}
         )
 
     key = ("test", "demo", "polygon")
@@ -177,11 +169,6 @@ def remove_geo_indexes(connection):
 
     try:
         connection.index_remove("test", "geo_list_index")
-    except Exception:
-        pass
-
-    try:
-        connection.index_remove("test", "geo_map_key_index")
     except Exception:
         pass
 
@@ -982,7 +969,6 @@ class TestGeospatial(object):
         "bin_name, idx_type",
         (
             ("geo_list", aerospike.INDEX_TYPE_LIST),
-            ("geo_map_keys", aerospike.INDEX_TYPE_MAPKEYS),
             ("geo_map_vals", aerospike.INDEX_TYPE_MAPVALUES),
         ),
     )
@@ -1006,7 +992,6 @@ class TestGeospatial(object):
         "bin_name, idx_type",
         (
             ("geo_list", aerospike.INDEX_TYPE_LIST),
-            ("geo_map_keys", aerospike.INDEX_TYPE_MAPKEYS),
             ("geo_map_vals", aerospike.INDEX_TYPE_MAPVALUES),
         ),
     )


### PR DESCRIPTION
Docs:
https://aerospike-python-client--584.org.readthedocs.build/en/584/aerospike.html#aerospike.POLICY_KEY_SEND
https://aerospike-python-client--584.org.readthedocs.build/en/584/data_mapping.html#data-mappings

Extra changes:
- Modified test_expressions_map.py so it passes on both servers < 7.1 and server 7.1.
- test_geospatial.py: only run certain tests on server < 7.1