### PR TITLE
[CLIENT-2842] Fix client config batch_write, batch_remove, and batch_apply policies not being applied to Write, Remove, and Apply BatchRecords respectively

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -199,6 +199,7 @@ jobs:
 
     - name: Upload wheels to GitHub
       uses: actions/upload-artifact@v4
+      if: ${{ always() }}
       with:
         path: ./wheelhouse/*.whl
         name: ${{ matrix.python }}-manylinux_${{ matrix.platform }}.build
@@ -282,6 +283,7 @@ jobs:
 
     - name: Save macOS wheel
       uses: actions/upload-artifact@v4
+      if: ${{ always() }}
       with:
         name: ${{ matrix.python }}-macosx_x86_64.build
         path: wheelhouse/*.whl
@@ -395,6 +397,7 @@ jobs:
 
     - name: Save macOS wheel
       uses: actions/upload-artifact@v4
+      if: ${{ always() }}
       with:
         name: ${{ matrix.python-version[0] }}-macosx_arm64.build
         path: wheelhouse/*.whl

--- a/test/new_tests/as_status_codes.py
+++ b/test/new_tests/as_status_codes.py
@@ -9,6 +9,7 @@ Roughly maps to: exception_types.h
 class AerospikeStatus(object):
     AEROSPIKE_OK = 0
     AEROSPIKE_MAX_ERROR_RATE = -14
+    AEROSPIKE_BATCH_FAILED = -16
     AEROSPIKE_SERVER_ERROR = -10
     AEROSPIKE_INVALID_HOST = -4
     AEROSPIKE_ERR_CLIENT = -1

--- a/test/new_tests/test_batch_write.py
+++ b/test/new_tests/test_batch_write.py
@@ -488,3 +488,55 @@ class TestBatchWrite(TestBaseClass):
         with pytest.raises(e.ParamError) as excinfo:
             self.as_connection.batch_write(batch_records)
         assert excinfo.value.msg == "batch_type: Read, failed to convert policy"
+
+    @pytest.mark.parametrize(
+        "policy_name, batch_record",
+        [
+            (
+                "batch_write",
+                br.Write(
+                    key=("test", "demo", 0),
+                    ops=[
+                        op.write(bin_name="a", write_item=1)
+                    ]
+                )
+            ),
+            (
+                "batch_apply",
+                br.Apply(
+                    key=("test", "demo", 0),
+                    module="sample",
+                    function="list_append",
+                    args=["ilist_bin", 200]
+                ),
+            )
+        ]
+    )
+    def test_global_batch_policies_with_br_classes(self, policy_name: str, batch_record: br.BatchRecord):
+        config = TestBaseClass.get_connection_config()
+        config["policies"][policy_name] = {
+            "key": aerospike.POLICY_KEY_SEND
+        }
+        c = aerospike.client(config)
+        batch_records = br.BatchRecords(
+            batch_records=[
+                batch_record
+            ]
+        )
+        c.batch_write(batch_records)
+
+        query = self.as_connection.query(self.test_ns, self.test_set)
+        records = query.results()
+        # Only the record with primary key 0 should have its PK returned from the query
+        # The other records should not have a PK returned from the server
+        for record_tuple in records:
+            key_tuple = record_tuple[0]
+            pk = key_tuple[2]
+            # Use count bin to identify record's PK
+            bins = record_tuple[2]
+            if bins["count"] == 0:
+                # Get key tuple with PK 0
+                expected_key_tuple = self.keys[0]
+                assert pk == expected_key_tuple[2]
+            else:
+                assert pk is None

--- a/test/new_tests/test_batch_write.py
+++ b/test/new_tests/test_batch_write.py
@@ -553,12 +553,9 @@ class TestBatchWrite(TestBaseClass):
             batch_records=[
                 br.Remove(
                     key=("test", "demo", 0),
-                    policy={
-                        "gen": aerospike.POLICY_GEN_EQ,
-                        "generation": 42
-                    }
                 )
             ]
         )
-        with pytest.raises(e.RecordGenerationError):
-            c.batch_write(batch_records)
+        brs = c.batch_write(batch_records)
+        assert brs.result == AerospikeStatus.AEROSPIKE_BATCH_FAILED
+        assert brs.batch_records[0].result == AerospikeStatus.AEROSPIKE_ERR_RECORD_GENERATION


### PR DESCRIPTION
Extra changes:
- build-wheels.yml: upload macOS and manylinux wheels to Github even if the tests fail

It's already documented that these 3 policies apply to Write, Apply, and Remove BatchRecords here: https://aerospike-python-client--591.org.readthedocs.build/en/591/client.html#batch-write-policies