### PR TITLE
[CLIENT-2851] Doc: Add note about bug with passing only read operations in client.batch_operate()

### DIFF
--- a/doc/client.rst
+++ b/doc/client.rst
@@ -362,6 +362,9 @@ Batch Operations
 
         Perform the same read/write transactions on multiple keys.
 
+        .. note:: There is a bug in Python client < 14.0.0 where only passing read operations does not work. This bug
+            is fixed in Python client 14.0.0.
+
         :param list keys: The keys to operate on.
         :param list ops: List of operations to apply.
         :param dict policy_batch: See :ref:`aerospike_batch_policies`.

--- a/doc/client.rst
+++ b/doc/client.rst
@@ -362,8 +362,8 @@ Batch Operations
 
         Perform the same read/write transactions on multiple keys.
 
-        .. note:: There is a bug in Python client < 14.0.0 where only passing read operations does not work. This bug
-            is fixed in Python client 14.0.0.
+        .. note:: Prior to Python client 14.0.0, using the :meth:`~batch_operate()` method with only read operations caused an error.
+            This bug was fixed in version 14.0.0.
 
         :param list keys: The keys to operate on.
         :param list ops: List of operations to apply.

--- a/doc/examples/batch_operate.py
+++ b/doc/examples/batch_operate.py
@@ -11,8 +11,6 @@ for key, bin in zip(keys, bins):
     client.put(key, bin)
 
 # Increment ID by 100 and balance by 500 for all employees
-# NOTE: batch_operate ops must include a write op
-# get_batch_ops or get_many can be used for all read ops use cases.
 ops = [
     op.increment("id", 100),
     op.increment("balance", 500),


### PR DESCRIPTION
https://aerospike-python-client--594.org.readthedocs.build/en/594/client.html#aerospike.Client.batch_operate