### PR TITLE
[CLIENT-1837] CI/CD: Add option to upload JFrog builds to PyPI

### DIFF
--- a/.github/workflows/upload-jfrog-build-to-pypi.yml
+++ b/.github/workflows/upload-jfrog-build-to-pypi.yml
@@ -1,0 +1,33 @@
+name: Publish JFrog build to PyPI
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        type: string
+        description: Build version
+        required: true
+      use-test-pypi:
+        type: boolean
+        description: 'DEBUG: upload to test.pypi.org?'
+        required: true
+        default: false
+
+jobs:
+  publish-jfrog-build-to-pypi:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: jfrog/setup-jfrog-cli@v4
+      env:
+        JF_URL: ${{ secrets.JFROG_PLATFORM_URL }}
+        JF_ACCESS_TOKEN: ${{ secrets.JFROG_ACCESS_TOKEN }}
+
+    - name: Download JFrog build
+      run: jf rt dl --build python-client/${{ inputs.version }} ${{ vars.JFROG_REPO_NAME }}
+
+    - name: Publish package distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        # This is the directory jf downloads the artifacts to
+        packages-dir: aerospike/${{ inputs.version }}/artifacts
+        repository-url: ${{ inputs.use-test-pypi && 'https://test.pypi.org/legacy/' || 'https://pypi.org/legacy/' }}
+        password: ${{ inputs.use-test-pypi && secrets.TEST_PYPI_API_TOKEN || secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/upload-jfrog-build-to-pypi.yml
+++ b/.github/workflows/upload-jfrog-build-to-pypi.yml
@@ -1,5 +1,6 @@
 name: Publish JFrog build to PyPI
 on:
+  pull_request:
   workflow_dispatch:
     inputs:
       version:
@@ -14,6 +15,7 @@ on:
 
 jobs:
   publish-jfrog-build-to-pypi:
+    if: ${{ false }}
     runs-on: ubuntu-22.04
     steps:
     - uses: jfrog/setup-jfrog-cli@v4

--- a/.github/workflows/upload-jfrog-build-to-pypi.yml
+++ b/.github/workflows/upload-jfrog-build-to-pypi.yml
@@ -1,6 +1,5 @@
 name: Publish JFrog build to PyPI
 on:
-  pull_request:
   workflow_dispatch:
     inputs:
       version:
@@ -15,7 +14,6 @@ on:
 
 jobs:
   publish-jfrog-build-to-pypi:
-    if: ${{ false }}
     runs-on: ubuntu-22.04
     steps:
     - uses: jfrog/setup-jfrog-cli@v4


### PR DESCRIPTION
Successful download and publishing of JFrog artifacts to Test PyPI: https://github.com/aerospike/aerospike-client-python/actions/runs/8606094945/job/23583782412
Publishing a nonexistent JFrog build fails: https://github.com/aerospike/aerospike-client-python/actions/runs/8606227878/job/23584197210