### PR TITLE
[CLIENT-2856] Docs: Clarify how list order works and add link to explain negative indices

### DIFF
--- a/aerospike_helpers/operations/list_operations.py
+++ b/aerospike_helpers/operations/list_operations.py
@@ -173,7 +173,7 @@ def list_insert_items(bin_name: str, index, values, policy: Optional[dict] = Non
     Creates a list insert items operation.
 
     The list insert items operation inserts items at index: `index` into the list contained
-    in the specified bin.
+    in the specified bin. Server returns list size.
 
     Args:
         bin_name (str): The name of the bin to be operated on.
@@ -280,7 +280,8 @@ def list_remove(bin_name: str, index, ctx: Optional[list] = None):
     """
     Creates a list remove operation.
 
-    The list remove operation removes an item located at `index` in the list specified by `bin_name`
+    The list remove operation removes an item located at `index` in the list specified by `bin_name`.
+    Server returns number of items removed.
 
     Args:
         bin_name (str): The name of the bin containing the item to be removed.
@@ -304,7 +305,7 @@ def list_remove_range(bin_name: str, index, count, ctx: Optional[list] = None):
     Creates a list remove range operation.
 
     The list remove range operation removes `count` items starting at `index`
-    in the list specified by `bin_name`
+    in the list specified by `bin_name`. Server returns number of items removed.
 
     Args:
         bin_name (str): The name of the bin containing the items to be removed.
@@ -349,7 +350,8 @@ def list_clear(bin_name: str, ctx: Optional[list] = None):
 def list_set(bin_name: str, index, value, policy: Optional[dict] = None, ctx: Optional[list] = None):
     """Create a list set operation.
 
-    The list set operations sets the value of the item at `index` to `value`
+    The list set operations sets the value of the item at `index` to `value`.
+    Server does not return a result by default.
 
     Args:
         bin_name (str): The name of the bin containing the list to be operated on.

--- a/aerospike_helpers/operations/list_operations.py
+++ b/aerospike_helpers/operations/list_operations.py
@@ -22,6 +22,9 @@ This module provides helper functions to produce dictionaries to be used with:
 List operations support nested CDTs through an optional ctx context argument.
 The ctx argument is a list of cdt_ctx context operation objects. See :class:`aerospike_helpers.cdt_ctx`.
 
+For list operations that take in an index parameter, you can use negative values for indexes.
+See this `page <https://aerospike.com/docs/server/guide/data-types/cdt-list#list-terminology>`_.
+
 .. note:: Nested CDT (ctx) requires server version >= 4.6.0
 
 """

--- a/doc/aerospike.rst
+++ b/doc/aerospike.rst
@@ -1049,7 +1049,7 @@ Flags used by list order.
     Ordered list.
 
 .. note::
-    See `this page <https://aerospike.com/docs/server/guide/data-types/cdt-list#unordered-lists>`_ for more info.
+    See `this page <https://aerospike.com/docs/server/guide/data-types/cdt-list#unordered-lists>`_ to learn more about list ordering.
 
 .. _aerospike_list_sort_flag:
 

--- a/doc/aerospike.rst
+++ b/doc/aerospike.rst
@@ -1048,6 +1048,9 @@ Flags used by list order.
 
     Ordered list.
 
+.. note::
+    See `this page <https://aerospike.com/docs/server/guide/data-types/cdt-list#unordered-lists>`_ for more info.
+
 .. _aerospike_list_sort_flag:
 
 List Sort Flags

--- a/test/new_tests/test_operate_helpers.py
+++ b/test/new_tests/test_operate_helpers.py
@@ -583,6 +583,29 @@ class TestOperate(object):
         self.as_connection.remove(key)
 
     @pytest.mark.parametrize(
+        "ops, expected_result",
+        [
+            (
+                [
+                    # Fetch the last item in the list
+                    list_operations.list_get(bin_name="int_bin", index=-1)
+                ],
+                4
+            ),
+            (
+                [
+                    list_operations.list_get_range(bin_name="int_bin", index=-2, count=2)
+                ],
+                [3, 4]
+            )
+        ]
+    )
+    def test_list_get_ops_with_negative_index(self, ops: list, expected_result: int):
+        key = ("test", "demo", "list_key")
+        _, _, bins = self.as_connection.operate(key, ops)
+        assert bins["int_bin"] == expected_result
+
+    @pytest.mark.parametrize(
         "list, result, bin, expected",
         [
             (
@@ -641,6 +664,91 @@ class TestOperate(object):
                 "int_bin",
                 [1, 2, 3, 4, None, None, 10],  # Inserting outside of the range adds nils in between
             ),
+            # Negative index tests
+            (
+                [
+                    list_operations.list_increment(bin_name="int_bin", index=-1, value=4),
+                    list_operations.list_get(bin_name="int_bin", index=3)
+                ],
+                {"int_bin": 8},
+                "int_bin",
+                [1, 2, 3, 8]
+            ),
+            (
+                [
+                    list_operations.list_insert_items(bin_name="int_bin", index=-1, values=[5, 6]),
+                ],
+                {"int_bin": 6},
+                "int_bin",
+                [1, 2, 3, 5, 6, 4]
+            ),
+            # We also include list removal operations here since they return something
+            # The test function below doesn't test for the return value of the operations
+            (
+                [
+                    list_operations.list_pop(bin_name="int_bin", index=-1),
+                ],
+                {"int_bin": 4},
+                "int_bin",
+                [1, 2, 3]
+            ),
+            (
+                [
+                    list_operations.list_pop_range(bin_name="int_bin", index=-2, count=2),
+                ],
+                {"int_bin": [3, 4]},
+                "int_bin",
+                [1, 2]
+            ),
+            (
+                [
+                    list_operations.list_remove(bin_name="int_bin", index=-1),
+                ],
+                {"int_bin": 1},
+                "int_bin",
+                [1, 2, 3]
+            ),
+            (
+                [
+                    list_operations.list_remove_by_index(
+                        bin_name="int_bin",
+                        index=-1,
+                        return_type=aerospike.LIST_RETURN_VALUE
+                    ),
+                ],
+                {"int_bin": 4},
+                "int_bin",
+                [1, 2, 3]
+            ),
+            (
+                [
+                    list_operations.list_remove_by_index_range(
+                        bin_name="int_bin",
+                        index=-2,
+                        return_type=aerospike.LIST_RETURN_VALUE,
+                        count=2
+                    ),
+                ],
+                {"int_bin": [3, 4]},
+                "int_bin",
+                [1, 2]
+            ),
+            (
+                [
+                    list_operations.list_remove_range(bin_name="int_bin", index=-2, count=2)
+                ],
+                {"int_bin": 2},
+                "int_bin",
+                [1, 2]
+            ),
+            (
+                [
+                    list_operations.list_set(bin_name="int_bin", index=-1, value=44)
+                ],
+                {},
+                "int_bin",
+                [1, 2, 3, 44]
+            )
         ],
     )
     def test_pos_operate_with_list_addition_operations(self, list, result, bin, expected):
@@ -663,6 +771,14 @@ class TestOperate(object):
             ([list_operations.list_remove_range("int_bin", 2, 2)], "int_bin", [1, 2]),
             ([list_operations.list_trim("int_bin", 2, 2)], "int_bin", [3, 4]),
             ([list_operations.list_clear("int_bin")], "int_bin", []),
+            # Negative index tests
+            (
+                [
+                    list_operations.list_trim(bin_name="int_bin", index=-3, count=3)
+                ],
+                "int_bin",
+                [2, 3, 4]
+            )
         ],
     )
     def test_pos_operate_with_list_remove_operations(self, list, bin, expected):


### PR DESCRIPTION
addresses issues 5 and 6 by customer

Extra changes. These is behavior not documented in the Python client but is documented in the C client:
- https://aerospike-python-client--602.org.readthedocs.build/en/602/aerospike_helpers.operations.html#aerospike_helpers.operations.list_operations.list_insert_items
- https://aerospike-python-client--602.org.readthedocs.build/en/602/aerospike_helpers.operations.html#aerospike_helpers.operations.list_operations.list_remove
- https://aerospike-python-client--602.org.readthedocs.build/en/602/aerospike_helpers.operations.html#aerospike_helpers.operations.list_operations.list_remove_range
- https://aerospike-python-client--602.org.readthedocs.build/en/602/aerospike_helpers.operations.html#aerospike_helpers.operations.list_operations.list_set

Negative indexes: https://aerospike-python-client--602.org.readthedocs.build/en/602/aerospike_helpers.operations.html#module-aerospike_helpers.operations.list_operations
List ordering: https://aerospike-python-client--602.org.readthedocs.build/en/602/aerospike.html#list-order

Negative index tests already exist for:
- [list_get_by_index](https://github.com/aerospike/aerospike-client-python/blob/CLIENT-2856-cdt-order/test/new_tests/test_new_list_operation_helpers.py#L40)
- [list_get_by_index_range](https://github.com/aerospike/aerospike-client-python/blob/CLIENT-2856-cdt-order/test/new_tests/test_new_list_operation_helpers.py#L72)
- [list_insert](https://github.com/aerospike/aerospike-client-python/blob/CLIENT-2856-cdt-order/test/new_tests/test_operate_helpers.py#L746)