### PR TITLE
[CLIENT-2203] CI/CD: Fix codecov.io upload errors by using a token

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -214,6 +214,8 @@ jobs:
         directory: coverage-report
         verbose: true # optional (default = false)
         fail_ci_if_error: true
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   stubtest:
     needs: build


### PR DESCRIPTION
Reran coverage upload job twice and it passes again