### PR TITLE
[CLIENT-2904] Add support for macOS 13

### DIFF
--- a/.github/workflows/stage-tests.yml
+++ b/.github/workflows/stage-tests.yml
@@ -309,6 +309,7 @@ jobs:
       matrix:
         macos-version: [
           'macos-11',
+          'macos-13'
         ]
         python-version: [
           ["3.8", "cp38"],

--- a/.github/workflows/stage-tests.yml
+++ b/.github/workflows/stage-tests.yml
@@ -344,7 +344,7 @@ jobs:
 
     - uses: ./.github/actions/run-ee-server
       with:
-        use-server-rc: true
+        use-server-rc: ${{ inputs.use-server-rc }}
         server-tag: ${{ inputs.server-tag }}
         docker-hub-username: ${{ secrets.DOCKER_HUB_BOT_USERNAME }}
         docker-hub-password: ${{ secrets.DOCKER_HUB_BOT_PW }}

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ Compatibility
 
 The Python client for Aerospike works with Python 3.8 - 3.12 and supports the following OS'es:
 
-* macOS 11 and 12
+* macOS 11, 12, and 13
 * CentOS 7 Linux
 * RHEL 8 and 9
 * Amazon Linux 2023


### PR DESCRIPTION
Extra changes:
- Fix bug where macOS stage tests always use server RC

Tests pass on macOS 13: https://github.com/aerospike/aerospike-client-python/actions/runs/8884125090/job/24393025635