### PR TITLE
[CLIENT-2736] Remove macOS 11 support

### DIFF
--- a/.github/workflows/stage-tests.yml
+++ b/.github/workflows/stage-tests.yml
@@ -308,7 +308,6 @@ jobs:
     strategy:
       matrix:
         macos-version: [
-          'macos-11',
           'macos-13'
         ]
         python-version: [

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ Compatibility
 
 The Python client for Aerospike works with Python 3.8 - 3.12 and supports the following OS'es:
 
-* macOS 11, 12, and 13
+* macOS 12 and 13
 * CentOS 7 Linux
 * RHEL 8 and 9
 * Amazon Linux 2023


### PR DESCRIPTION
Stage tests without macos 11: https://github.com/aerospike/aerospike-client-python/actions/runs/8898394464