### PR TITLE
[CLIENT-2701] Fix memory leak that occurs when creating an aerospike_helpers class instance with a parameter

### DIFF
--- a/src/main/conversions.c
+++ b/src/main/conversions.c
@@ -1011,6 +1011,7 @@ error:
     return NULL;
 }
 
+// Does not steal a reference to py_arg
 PyObject *create_class_instance_from_module(as_error *error_p,
                                             const char *module_name,
                                             const char *class_name,

--- a/src/main/serializer.c
+++ b/src/main/serializer.c
@@ -488,6 +488,7 @@ extern as_status deserialize_based_on_as_bytes_type(AerospikeClient *self,
         }
         PyObject *py_hll = create_class_instance_from_module(
             error_p, "aerospike_helpers", "HyperLogLog", py_bytes);
+        Py_DECREF(py_bytes);
         if (!py_hll) {
             goto CLEANUP;
         }


### PR DESCRIPTION
Memory usage after running the full test suites is now back to normal as before the metrics changes. No memory errors from running valgrind on this branch

dev: https://github.com/aerospike/aerospike-client-python/actions/runs/8884233073
this branch: https://github.com/aerospike/aerospike-client-python/actions/runs/8897726512
Before metrics changes: https://github.com/aerospike/aerospike-client-python/actions/runs/8886114249