### PR TITLE
[CLIENT-2858] Docs: Clarify that deleting all keys in a map does not delete the map itself

### DIFF
--- a/aerospike_helpers/operations/map_operations.py
+++ b/aerospike_helpers/operations/map_operations.py
@@ -22,6 +22,10 @@ Helper functions to create map operation dictionaries arguments for:
 Map operations support nested CDTs through an optional ctx context argument.
 The ctx argument is a list of cdt_ctx context operation objects. See :class:`aerospike_helpers.cdt_ctx`.
 
+For the map operations that remove map items, such as :mod:`~aerospike_helpers.operations.map_operations.map_clear` and
+all the ``remove_*`` operations, if all map items are removed in a map, the map becomes empty (i.e it does not get
+deleted).
+
 .. note:: Nested CDT (ctx) requires server version >= 4.6.0
 
 """

--- a/test/new_tests/test_operate_map.py
+++ b/test/new_tests/test_operate_map.py
@@ -444,27 +444,6 @@ class TestOperate(object):
         _, _, bins = self.as_connection.operate(self.test_map_key, ops)
         assert bins["cool_list"] == [1, 2, 3]
 
-    def test_map_remove_by_key_causing_empty_map(self):
-        # Add a map bin with only 1 key on the fly only for this test case
-        map_with_one_key_bin_name = "map_w_one_key"
-        bins = {
-            map_with_one_key_bin_name: {"a": 1}
-        }
-        self.as_connection.put(self.test_map_key, bins)
-
-        ops = [
-            map_operations.map_remove_by_key(
-                bin_name=map_with_one_key_bin_name,
-                key="a",
-                return_type=aerospike.MAP_RETURN_NONE
-            )
-        ]
-        self.as_connection.operate(self.test_map_key, ops)
-
-        _, _, bins = self.as_connection.get(self.test_map_key)
-        # "a" should've been deleted
-        assert bins[map_with_one_key_bin_name] == {}
-
     def test_map_remove_by_key_ret_key_val_test_with_list_read_even(self):
         self.test_map.copy()
         self.as_connection.put(self.test_map_key, {"cool_list": [1, 2, 3, 4]})

--- a/test/new_tests/test_operate_map.py
+++ b/test/new_tests/test_operate_map.py
@@ -444,6 +444,27 @@ class TestOperate(object):
         _, _, bins = self.as_connection.operate(self.test_map_key, ops)
         assert bins["cool_list"] == [1, 2, 3]
 
+    def test_map_remove_by_key_causing_empty_map(self):
+        # Add a map bin with only 1 key on the fly only for this test case
+        map_with_one_key_bin_name = "map_w_one_key"
+        bins = {
+            map_with_one_key_bin_name: {"a": 1}
+        }
+        self.as_connection.put(self.test_map_key, bins)
+
+        ops = [
+            map_operations.map_remove_by_key(
+                bin_name=map_with_one_key_bin_name,
+                key="a",
+                return_type=aerospike.MAP_RETURN_NONE
+            )
+        ]
+        self.as_connection.operate(self.test_map_key, ops)
+
+        _, _, bins = self.as_connection.get(self.test_map_key)
+        # "a" should've been deleted
+        assert bins[map_with_one_key_bin_name] == {}
+
     def test_map_remove_by_key_ret_key_val_test_with_list_read_even(self):
         self.test_map.copy()
         self.as_connection.put(self.test_map_key, {"cool_list": [1, 2, 3, 4]})


### PR DESCRIPTION
Added missing test coverage for map operations to check if deleting all map items yields an empty map

Documentation changes:

https://aerospike-python-client--615.org.readthedocs.build/en/615/aerospike_helpers.operations.html#module-aerospike_helpers.operations.map_operations

Tests already exist for:
- map_clear(): https://github.com/aerospike/aerospike-client-python/blob/CLIENT-2856-doc-map-policy/test/new_tests/test_nested_cdt_ctx.py#L2923
- map_remove_by_key_list(): https://github.com/aerospike/aerospike-client-python/blob/CLIENT-2856-doc-map-policy/test/new_tests/test_nested_cdt_ctx.py#L3174
- map_remove_by_index_range(): https://github.com/aerospike/aerospike-client-python/blob/CLIENT-2858-clarify-empty-maps/test/new_tests/test_nested_cdt_ctx.py#L4019
- map_remove_by_key_index_range_relative(): https://github.com/aerospike/aerospike-client-python/blob/CLIENT-2858-clarify-empty-maps/test/new_tests/test_nested_cdt_ctx.py#L4610
- map_remove_by_key_range(): https://github.com/aerospike/aerospike-client-python/blob/CLIENT-2858-clarify-empty-maps/test/new_tests/test_nested_cdt_ctx.py#L3299
- map_remove_by_rank_range(): https://github.com/aerospike/aerospike-client-python/blob/CLIENT-2858-clarify-empty-maps/test/new_tests/test_nested_cdt_ctx.py#L4277
- map_remove_by_value_list(): https://github.com/aerospike/aerospike-client-python/blob/CLIENT-2858-clarify-empty-maps/test/new_tests/test_nested_cdt_ctx.py#L3610
- map_remove_by_value_range(): https://github.com/aerospike/aerospike-client-python/blob/CLIENT-2858-clarify-empty-maps/test/new_tests/test_nested_cdt_ctx.py#L3735
- map_remove_by_value_rank_range_relative(): https://github.com/aerospike/aerospike-client-python/blob/CLIENT-2858-clarify-empty-maps/test/new_tests/test_nested_cdt_ctx.py#L4401