### PR TITLE
[CLIENT-1938] Remove aerospike.__version__ to single source the client's version

### DIFF
--- a/.github/actions/update-version/action.yml
+++ b/.github/actions/update-version/action.yml
@@ -8,10 +8,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-  - name: Update __version__ in aerospike module
-    run: sed -i "s/const char version\[] = \".*\";/const char version\[] = \"${{ inputs.new_version }}\";/" src/main/aerospike.c
-    shell: bash
-
   - name: Update VERSION metadata
     run: echo ${{ inputs.new_version }} > VERSION
     shell: bash

--- a/BUILD.md
+++ b/BUILD.md
@@ -130,8 +130,6 @@ The local version identifier will appear in:
 - The package version in the wheel name
 - `python3 -m pip show aerospike` if you installed the wheel
 
-The local version identifier will NOT show up in `aerospike.__version__`.
-
 ### Unoptimized builds (only Linux and macOS)
 
 By default, the Python client and the C client submodule are built with optimizations, which can make debugging

--- a/doc/aerospike.rst
+++ b/doc/aerospike.rst
@@ -1412,12 +1412,6 @@ Bin Types
 Miscellaneous
 -------------
 
-.. data:: __version__
-
-    A :class:`str` containing the module's version.
-
-    .. versionadded:: 1.0.54
-
 .. data:: UDF_TYPE_LUA
 
     UDF type is LUA (which is the only UDF type).

--- a/scripts/manylinux2014build.sh
+++ b/scripts/manylinux2014build.sh
@@ -17,7 +17,7 @@ done
 
 for i in "${ADDR[@]}"; do
     ${i}/pip install aerospike -f /work/wheels/
-    ${i}/python -c "import aerospike; print('Installed aerospike version{}'.format(aerospike.__version__))"
+    ${i}/python -c "import aerospike; from importlib.metadata import version; print('Installed aerospike version{}'.format(version('aerospike')))"
 done
 
 echo "Building wheel $PYTHONS are done"

--- a/src/main/aerospike.c
+++ b/src/main/aerospike.c
@@ -137,8 +137,6 @@ static int Aerospike_Clear(PyObject *aerospike)
 
 PyMODINIT_FUNC PyInit_aerospike(void)
 {
-
-    const char version[] = "15.0.1rc3.dev3";
     // Makes things "thread-safe"
     Py_Initialize();
     int i = 0;

--- a/src/main/aerospike.c
+++ b/src/main/aerospike.c
@@ -161,8 +161,6 @@ PyMODINIT_FUNC PyInit_aerospike(void)
 
     py_global_hosts = PyDict_New();
 
-    PyModule_AddStringConstant(aerospike, "__version__", version);
-
     PyObject *exception = AerospikeException_New();
     Py_INCREF(exception);
     int retval = PyModule_AddObject(aerospike, "exception", exception);

--- a/test/new_tests/test_connect.py
+++ b/test/new_tests/test_connect.py
@@ -27,12 +27,6 @@ def open_as_connection(config):
 # adds cls.connection_config to this class
 @pytest.mark.usefixtures("connection_config")
 class TestConnect(object):
-    def test_version(self):
-        """
-        Check for aerospike vrsion
-        """
-        assert aerospike.__version__ is not None
-
     def test_connect_positive(self):
         """
         Invoke connect() with positive parameters.


### PR DESCRIPTION
Doc changes
https://aerospike-python-client--623.org.readthedocs.build/en/623/aerospike.html#miscellaneous

Regression test

Workflow to bump and update version still works: https://github.com/aerospike/aerospike-client-python/actions/runs/9287695613

TODO
- [x] delete tag generated by test workflow