### PR TITLE
[CLIENT-1837] CI/CD: Fix using the wrong repository URL when uploading JFrog builds to pypi.org

### DIFF
--- a/.github/workflows/upload-jfrog-build-to-pypi.yml
+++ b/.github/workflows/upload-jfrog-build-to-pypi.yml
@@ -29,5 +29,5 @@ jobs:
       with:
         # This is the directory jf downloads the artifacts to
         packages-dir: aerospike/${{ inputs.version }}/artifacts
-        repository-url: ${{ inputs.use-test-pypi && 'https://test.pypi.org/legacy/' || 'https://pypi.org/legacy/' }}
+        repository-url: ${{ inputs.use-test-pypi && 'https://test.pypi.org/legacy/' || 'https://upload.pypi.org/legacy/' }}
         password: ${{ inputs.use-test-pypi && secrets.TEST_PYPI_API_TOKEN || secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
This fix allowed me to upload 15.0.1rc2 from JFrog to PyPI: https://github.com/aerospike/aerospike-client-python/actions/runs/9323099458

The test.pypi.org link worked before, but not the pypi.org link