### PR TITLE
[CLIENT-3000] Fix scans not working for a mixed cluster of 5.7 and 6.4 nodes (v14 backport)

### DIFF
--- a/.github/actions/run-ee-server/action.yml
+++ b/.github/actions/run-ee-server/action.yml
@@ -6,7 +6,7 @@ inputs:
     default: false
   server-tag:
     required: true
-    default: 'latest'
+    default: '7.0'
   # Github Composite Actions can't access secrets
   # so we need to pass them in as inputs
   docker-hub-username:

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -433,7 +433,7 @@ jobs:
           ["cp311", "3.11"],
           ["cp312", "3.12"]
         ]
-        os: [macos-latest]
+        os: [macos-12]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,4 +2,4 @@
 	path = aerospike-client-c
 	# url = git@github.com:aerospike/aerospike-client-c.git
 	url = https://github.com/aerospike/aerospike-client-c.git
-	branch = stage
+	branch = 6.5.1.X


### PR DESCRIPTION
C client changes: https://github.com/aerospike/aerospike-client-c/compare/29860294a714d254c71d4325d8242b66f7a773eb...54e25075646e815f023b5923603d35fa9d9b8f00

All wheels pass testing except for noise and some bugs in the workflow code: https://github.com/aerospike/aerospike-client-python/actions/runs/9666696374/
Valgrind shows no new memory errors from this PR: https://github.com/aerospike/aerospike-client-python/actions/runs/9717949772