### PR TITLE
[CLIENT-3000] Fix scans not working for a mixed cluster of 5.7 and 6.4 nodes (v13 backport)

### DIFF
--- a/.github/actions/run-ee-server/action.yml
+++ b/.github/actions/run-ee-server/action.yml
@@ -26,7 +26,7 @@ runs:
 
   - name: Use release server
     if: ${{ inputs.use-server-rc == 'false' }}
-    run: echo "SERVER_IMAGE=aerospike/aerospike-server-enterprise" >> $GITHUB_ENV
+    run: echo "SERVER_IMAGE=aerospike/aerospike-server-enterprise:7.0" >> $GITHUB_ENV
     shell: bash
 
   - name: Use release candidate server
@@ -36,7 +36,7 @@ runs:
 
   - name: Get default aerospike.conf from Docker server EE container
     run: |
-      docker run -d --name aerospike -p 3000-3002:3000-3002 ${SERVER_IMAGE}:7.0
+      docker run -d --name aerospike -p 3000-3002:3000-3002 $SERVER_IMAGE
       sleep 5
       docker cp aerospike:/etc/aerospike/aerospike.conf ./configs/aerospike.conf
       docker container stop aerospike

--- a/.github/actions/run-ee-server/action.yml
+++ b/.github/actions/run-ee-server/action.yml
@@ -36,7 +36,7 @@ runs:
 
   - name: Get default aerospike.conf from Docker server EE container
     run: |
-      docker run -d --name aerospike -p 3000-3002:3000-3002 $SERVER_IMAGE
+      docker run -d --name aerospike -p 3000-3002:3000-3002 ${SERVER_IMAGE}:7.0
       sleep 5
       docker cp aerospike:/etc/aerospike/aerospike.conf ./configs/aerospike.conf
       docker container stop aerospike

--- a/.github/actions/run-ee-server/action.yml
+++ b/.github/actions/run-ee-server/action.yml
@@ -26,7 +26,7 @@ runs:
 
   - name: Use release server
     if: ${{ inputs.use-server-rc == 'false' }}
-    run: echo "SERVER_IMAGE=aerospike/aerospike-server-enterprise:7.0" >> $GITHUB_ENV
+    run: echo "SERVER_IMAGE=aerospike/aerospike-server-enterprise:6.4" >> $GITHUB_ENV
     shell: bash
 
   - name: Use release candidate server

--- a/.github/actions/run-ee-server/action.yml
+++ b/.github/actions/run-ee-server/action.yml
@@ -4,19 +4,30 @@ inputs:
   use-server-rc:
     required: true
     default: false
+  server-tag:
+    required: true
+    default: 'latest'
+  # Github Composite Actions can't access secrets
+  # so we need to pass them in as inputs
+  docker-hub-username:
+    required: false
+    type: string
+  docker-hub-password:
+    required: false
+    type: string
 
 runs:
   using: "composite"
   steps:
   - name: Install crudini to manipulate config.conf
-    run: pip install crudini==0.9.4
+    run: python3 -m pip install crudini==0.9.4
     shell: bash
 
   - name: Add enterprise edition config to config.conf
     run: |
-      crudini --set config.conf enterprise-edition hosts 127.0.0.1:3000
-      crudini --set config.conf enterprise-edition user superuser
-      crudini --set config.conf enterprise-edition password superuser
+      python3 -m crudini --set config.conf enterprise-edition hosts 127.0.0.1:3000
+      python3 -m crudini --set config.conf enterprise-edition user superuser
+      python3 -m crudini --set config.conf enterprise-edition password superuser
     working-directory: test
     shell: bash
 
@@ -31,7 +42,12 @@ runs:
 
   - name: Use release candidate server
     if: ${{ inputs.use-server-rc == 'true' }}
-    run: echo "SERVER_IMAGE=aerospike.jfrog.io/docker/aerospike/aerospike-server-enterprise-rc" >> $GITHUB_ENV
+    run: echo "SERVER_IMAGE=aerospike/aerospike-server-enterprise-rc" >> $GITHUB_ENV
+    shell: bash
+
+  - name: Log into Docker Hub to get server RC
+    if: ${{ inputs.use-server-rc == 'true' }}
+    run: docker login --username ${{ inputs.docker-hub-username }} --password ${{ inputs.docker-hub-password }}
     shell: bash
 
   - name: Get default aerospike.conf from Docker server EE container

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -99,9 +99,16 @@ jobs:
       fail-fast: false
     runs-on: ubuntu-latest
     steps:
+
+    - if: ${{ inputs.use-server-rc }}
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKER_HUB_BOT_USERNAME }}
+        password: ${{ secrets.DOCKER_HUB_BOT_PW }}
+
     - name: Run Aerospike server release candidate with latest tag
       if: ${{ inputs.use-server-rc }}
-      run: docker run -d --name aerospike -p 3000-3002:3000-3002 aerospike.jfrog.io/docker/aerospike/aerospike-server-rc:latest
+      run: docker run -d --name aerospike -p 3000-3002:3000-3002 aerospike/aerospike-server-rc:latest
 
     - name: Run Aerospike server
       if: ${{ !inputs.use-server-rc }}
@@ -149,6 +156,9 @@ jobs:
     - uses: ./.github/actions/run-ee-server
       with:
         use-server-rc: ${{ inputs.use-server-rc }}
+        server-tag: ${{ inputs.server-tag }}
+        docker-hub-username: ${{ secrets.DOCKER_HUB_BOT_USERNAME }}
+        docker-hub-password: ${{ secrets.DOCKER_HUB_BOT_PW }}
 
     - name: Set config.conf to use Docker IP address of Aerospike server
       # config.conf should be copied into the cibuildwheel Docker container
@@ -205,6 +215,9 @@ jobs:
     - uses: ./.github/actions/run-ee-server
       with:
         use-server-rc: ${{ inputs.use-server-rc }}
+        server-tag: ${{ inputs.server-tag }}
+        docker-hub-username: ${{ secrets.DOCKER_HUB_BOT_USERNAME }}
+        docker-hub-password: ${{ secrets.DOCKER_HUB_BOT_PW }}
 
     - name: Wait for server to start
       run: sleep 5
@@ -278,7 +291,10 @@ jobs:
       runs-on: ubuntu-latest
       services:
         aerospike:
-          image: ${{ inputs.use-server-rc && 'aerospike.jfrog.io/docker/aerospike/aerospike-server-rc:latest' || 'aerospike/aerospike-server' }}
+          image: ${{ format('{0}:{1}', inputs.use-server-rc && 'aerospike/aerospike-server-rc' || 'aerospike/aerospike-server', inputs.server-tag) }}
+          credentials:
+            username: ${{ secrets.DOCKER_HUB_BOT_USERNAME }}
+            password: ${{ secrets.DOCKER_HUB_BOT_PW}}
       container:
         image: ${{ matrix.image }}
       steps:
@@ -315,7 +331,10 @@ jobs:
       runs-on: ubuntu-latest
       services:
         aerospike:
-          image: ${{ inputs.use-server-rc && 'aerospike.jfrog.io/docker/aerospike/aerospike-server-rc:latest' || 'aerospike/aerospike-server' }}
+          image: ${{ format('{0}:{1}', inputs.use-server-rc && 'aerospike/aerospike-server-rc' || 'aerospike/aerospike-server', inputs.server-tag) }}
+          credentials:
+            username: ${{ secrets.DOCKER_HUB_BOT_USERNAME }}
+            password: ${{ secrets.DOCKER_HUB_BOT_PW}}
       strategy:
         matrix:
           debian-name: [
@@ -351,7 +370,10 @@ jobs:
       runs-on: ubuntu-22.04
       services:
         aerospike:
-          image: ${{ inputs.use-server-rc && 'aerospike.jfrog.io/docker/aerospike/aerospike-server-rc:latest' || 'aerospike/aerospike-server' }}
+          image: ${{ format('{0}:{1}', inputs.use-server-rc && 'aerospike/aerospike-server-rc' || 'aerospike/aerospike-server', inputs.server-tag) }}
+          credentials:
+            username: ${{ secrets.DOCKER_HUB_BOT_USERNAME }}
+            password: ${{ secrets.DOCKER_HUB_BOT_PW}}
           ports:
             - 3000:3000
             - 3001:3001
@@ -398,10 +420,21 @@ jobs:
         submodules: recursive
         ref: ${{ github.ref_name }}
 
-    - name: Set up Python ${{ matrix.python-version[1] }}
-      uses: actions/setup-python@v3
+    - name: Install Docker Engine
+      run: brew install colima
+
+    - name: Install Docker client
+      run: brew install docker
+
+    - name: Start Docker Engine
+      run: colima start
+
+    - uses: ./.github/actions/run-ee-server
       with:
-        python-version: ${{ matrix.python-version[1] }}
+        use-server-rc: ${{ inputs.use-server-rc }}
+        server-tag: ${{ inputs.server-tag }}
+        docker-hub-username: ${{ secrets.DOCKER_HUB_BOT_USERNAME }}
+        docker-hub-password: ${{ secrets.DOCKER_HUB_BOT_PW }}
 
     - name: Build wheel
       uses: pypa/cibuildwheel@v2.11.2
@@ -411,9 +444,6 @@ jobs:
         CIBW_ENVIRONMENT: SSL_LIB_PATH="$(brew --prefix openssl@1.1)/lib/" CPATH="$(brew --prefix openssl@1.1)/include/" STATIC_SSL=1
         CIBW_ARCHS: "x86_64"
         CIBW_BEFORE_TEST: >
-          export USE_SERVER_RC=${{ inputs.use-server-rc }} &&
-          vagrant up &&
-          sleep 3 &&
           pip install -r test/requirements.txt
         CIBW_TEST_COMMAND: >
           cd {project}/test/ &&
@@ -457,9 +487,20 @@ jobs:
 
     - run: python${{ matrix.python-version }} -m pip install build delocate==0.10.4
 
+    # Self-hosted runner only
+    # Need to be able to save Docker Hub credentials to keychain
+    - run: security unlock-keychain -p ${{ secrets.MAC_M1_SELF_HOSTED_RUNNER_PW }}
+      if: ${{ inputs.use-server-rc }}
+
+    - if: ${{ inputs.use-server-rc }}
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKER_HUB_BOT_USERNAME }}
+        password: ${{ secrets.DOCKER_HUB_BOT_PW }}
+
     - name: Use server rc
       if: ${{ inputs.use-server-rc }}
-      run: echo IMAGE_NAME="aerospike.jfrog.io/docker/aerospike/aerospike-server-rc:latest" >> $GITHUB_ENV
+      run: echo IMAGE_NAME="aerospike/aerospike-server-rc:${{ inputs.server-tag }}" >> $GITHUB_ENV
 
     - name: Use server release
       if: ${{ !inputs.use-server-rc }}

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -1,5 +1,5 @@
 env:
-  SERVER_TAG: '7.0'
+  SERVER_TAG: '6.4'
 
 name: Build wheels
 

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -390,7 +390,7 @@ jobs:
           ["cp310", "3.10"],
           ["cp311", "3.11"]
         ]
-        os: [macos-latest]
+        os: [macos-12]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -105,7 +105,7 @@ jobs:
 
     - name: Run Aerospike server
       if: ${{ !inputs.use-server-rc }}
-      run: docker run -d --name aerospike -p 3000-3002:3000-3002 aerospike/aerospike-server
+      run: docker run -d --name aerospike -p 3000-3002:3000-3002 aerospike/aerospike-server:${{ env.SERVER_TAG }}
 
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -1,3 +1,6 @@
+env:
+  SERVER_TAG: '7.0'
+
 name: Build wheels
 
 # Builds wheels and sends to QE and Aerospike artifactory
@@ -15,6 +18,7 @@ on:
           - release
         default: 'rc'
         required: true
+      
 
 jobs:
   update-version:
@@ -46,10 +50,10 @@ jobs:
         sed -i "s/const char version\[] = \".*\";/const char version\[] = \"${{ env.NEW_TAG }}\";/" src/main/aerospike.c
         echo -e "${{ env.NEW_TAG }}" > VERSION
 
-    - name: Commit new version
-      uses: stefanzweifel/git-auto-commit-action@v4
-      with:
-        commit_message: Bump version to ${{ env.NEW_TAG }}
+    # - name: Commit new version
+    #   uses: stefanzweifel/git-auto-commit-action@v4
+    #   with:
+    #     commit_message: Bump version to ${{ env.NEW_TAG }}
 
   build-sdist:
     name: Build and install sdist
@@ -459,7 +463,7 @@ jobs:
 
     - name: Use server release
       if: ${{ !inputs.use-server-rc }}
-      run: echo IMAGE_NAME="aerospike/aerospike-server" >> $GITHUB_ENV
+      run: echo IMAGE_NAME="aerospike/aerospike-server:${{ env.SERVER_TAG }}" >> $GITHUB_ENV
 
     - name: Run server
       run: docker run -d -p 3000:3000 --name aerospike ${{ env.IMAGE_NAME }}
@@ -514,6 +518,7 @@ jobs:
       macOS-x86,
       macOS-m1,
     ]
+    if: ${{ false }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/download-artifact@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,6 +94,8 @@ jobs:
       uses: ./.github/actions/run-ee-server
       with:
         use-server-rc: ${{ contains(github.event.pull_request.labels.*.name, 'new-server-features') }}
+        docker-hub-username: ${{ secrets.DOCKER_HUB_BOT_USERNAME }}
+        docker-hub-password: ${{ secrets.DOCKER_HUB_BOT_PW }}
 
     - run: sleep 5
 
@@ -246,9 +248,15 @@ jobs:
     - name: Install test dependencies
       run: pip install -r test/requirements.txt
 
+    - if: ${{ contains(github.event.pull_request.labels.*.name, 'new-server-features') }}
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKER_HUB_BOT_USERNAME }}
+        password: ${{ secrets.DOCKER_HUB_BOT_PW }}
+
     - name: Run Aerospike server release candidate with latest tag
       if: ${{ contains(github.event.pull_request.labels.*.name, 'new-server-features') }}
-      run: docker run -d --name aerospike -p 3000-3002:3000-3002 aerospike.jfrog.io/docker/aerospike/aerospike-server-rc:latest
+      run: docker run -d --name aerospike -p 3000-3002:3000-3002 aerospike/aerospike-server-rc:latest
 
     - name: Run Aerospike server
       if: ${{ !contains(github.event.pull_request.labels.*.name, 'new-server-features') }}
@@ -324,6 +332,8 @@ jobs:
     - uses: ./.github/actions/run-ee-server
       with:
         use-server-rc: ${{ contains(github.event.pull_request.labels.*.name, 'new-server-features') }}
+        docker-hub-username: ${{ secrets.DOCKER_HUB_BOT_USERNAME }}
+        docker-hub-password: ${{ secrets.DOCKER_HUB_BOT_PW }}
 
     - name: Wait for server to start
       run: sleep 5

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -34,6 +34,8 @@ jobs:
       uses: ./.github/actions/run-ee-server
       with:
         use-server-rc: ${{ inputs.use-server-rc }}
+        docker-hub-username: ${{ secrets.DOCKER_HUB_BOT_USERNAME }}
+        docker-hub-password: ${{ secrets.DOCKER_HUB_BOT_PW }}
 
     - name: Wait for database to be ready
       # Should be ready after 3 seconds

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,4 +2,4 @@
 	path = aerospike-client-c
 	# url = git@github.com:aerospike/aerospike-client-c.git
 	url = https://github.com/aerospike/aerospike-client-c.git
-	branch = master
+	branch = 6.4.3.X


### PR DESCRIPTION
C client changes: https://github.com/aerospike/aerospike-client-c/compare/d1f5afbf09349dbeb5a9dda877d906ea5820a236...54e25075646e815f023b5923603d35fa9d9b8f00

All wheels pass testing except for some noise and syntax errors in the workflow code. I think it's sufficient enough to pass: https://github.com/aerospike/aerospike-client-python/actions/runs/9716046629/job/26818853889
Valgrind shows no memory errors coming from this PR: https://github.com/aerospike/aerospike-client-python/actions/runs/9716555070