### PR TITLE
[CLIENT-2996] CI/CD: Use Github ARM runners for ARM jobs

### DIFF
--- a/.github/actions/run-ee-server/action.yml
+++ b/.github/actions/run-ee-server/action.yml
@@ -19,7 +19,7 @@ runs:
   using: "composite"
   steps:
   - name: Install crudini to manipulate config.conf
-    run: pipx install crudini --pip-args "-c requirements.txt"
+    run: pipx install crudini --pip-args "-c ${{ github.workspace }}/.github/workflows/requirements.txt"
     working-directory: .github/workflows
     shell: bash
 

--- a/.github/actions/run-ee-server/action.yml
+++ b/.github/actions/run-ee-server/action.yml
@@ -19,7 +19,7 @@ runs:
   using: "composite"
   steps:
   - name: Install crudini to manipulate config.conf
-    run: pipx install crudini --pip-args -c requirements.txt
+    run: pipx install crudini --pip-args "-c requirements.txt"
     working-directory: .github/workflows
     shell: bash
 

--- a/.github/actions/run-ee-server/action.yml
+++ b/.github/actions/run-ee-server/action.yml
@@ -19,7 +19,7 @@ runs:
   using: "composite"
   steps:
   - name: Install crudini to manipulate config.conf
-    run: pip3 install crudini -c requirements.txt
+    run: pipx install crudini --pip-args -c requirements.txt
     working-directory: .github/workflows
     shell: bash
 

--- a/.github/actions/run-ee-server/action.yml
+++ b/.github/actions/run-ee-server/action.yml
@@ -19,6 +19,8 @@ runs:
   using: "composite"
   steps:
   - name: Install crudini to manipulate config.conf
+    # This will only work on the Github hosted runners.
+    # TODO: self hosted runners do not have pipx installed by default
     run: pipx install crudini --pip-args "-c ${{ github.workspace }}/.github/workflows/requirements.txt"
     working-directory: .github/workflows
     shell: bash

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -156,12 +156,6 @@ jobs:
         ref: ${{ inputs.ref }}
         fetch-depth: 0
 
-    - name: Set up QEMU for cross compiling arm64
-      if: ${{ matrix.platform[0] == 'aarch64' }}
-      uses: docker/setup-qemu-action@v2
-      with:
-        platforms: arm64
-
     - uses: ./.github/actions/run-ee-server-for-ext-container
       if: ${{ inputs.run_tests }}
       with:

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -126,7 +126,6 @@ jobs:
         context: "Build wheels (sdist)"
 
   manylinux:
-    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -139,17 +138,17 @@ jobs:
           "cp312"
         ]
         platform: [
-          "x86_64",
-          "aarch64"
+          ["x86_64", "ubuntu-22.04"],
+          ["aarch64", "aerospike_arm_runners_2"]
         ]
-
+    runs-on: ${{ matrix.platform[1] }}
     steps:
     - name: Show job status for commit
       uses: myrotvorets/set-commit-status-action@v2.0.0
       if: ${{ github.event_name != 'push' && github.event_name != 'pull_request' }}
       with:
         sha: ${{ github.sha }}
-        context: "Build wheels (${{ matrix.python }}-manylinux_${{ matrix.platform }})"
+        context: "Build wheels (${{ matrix.python }}-manylinux_${{ matrix.platform[0] }})"
 
     - uses: actions/checkout@v4
       with:
@@ -158,7 +157,7 @@ jobs:
         fetch-depth: 0
 
     - name: Set up QEMU for cross compiling arm64
-      if: ${{ matrix.platform == 'aarch64' }}
+      if: ${{ matrix.platform[0] == 'aarch64' }}
       uses: docker/setup-qemu-action@v2
       with:
         platforms: arm64
@@ -187,13 +186,13 @@ jobs:
       uses: pypa/cibuildwheel@v2.19.2
       env:
         CIBW_ENVIRONMENT_PASS_LINUX: ${{ inputs.apply-no-optimizations && 'UNOPTIMIZED' || '' }}
-        CIBW_BUILD: ${{ matrix.python }}-manylinux_${{ matrix.platform }}
+        CIBW_BUILD: ${{ matrix.python }}-manylinux_${{ matrix.platform[0] }}
         CIBW_BUILD_FRONTEND: build
         CIBW_BEFORE_ALL_LINUX: >
           yum install openssl-devel -y &&
           yum install python-devel -y &&
           yum install python-setuptools -y
-        CIBW_ARCHS: "${{ matrix.platform }}"
+        CIBW_ARCHS: "${{ matrix.platform[0] }}"
         CIBW_TEST_COMMAND: ${{ env.TEST_COMMAND }}
 
     - name: Upload wheels to GitHub
@@ -201,7 +200,7 @@ jobs:
       if: ${{ always() }}
       with:
         path: ./wheelhouse/*.whl
-        name: ${{ matrix.python }}-manylinux_${{ matrix.platform }}.build
+        name: ${{ matrix.python }}-manylinux_${{ matrix.platform[0] }}.build
 
     - name: Set final commit status
       uses: myrotvorets/set-commit-status-action@v2.0.0
@@ -209,7 +208,7 @@ jobs:
       with:
         sha: ${{ github.sha }}
         status: ${{ job.status }}
-        context: "Build wheels (${{ matrix.python }}-manylinux_${{ matrix.platform }})"
+        context: "Build wheels (${{ matrix.python }}-manylinux_${{ matrix.platform[0] }})"
 
   macOS-x86:
     strategy:

--- a/.github/workflows/stage-tests.yml
+++ b/.github/workflows/stage-tests.yml
@@ -64,7 +64,7 @@ jobs:
       fail-fast: false
     env:
       LINUX_DISTRO_CONTAINER_NAME: linux-distro
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.test-case[2] == 'linux/amd64' && 'ubuntu-22.04' || 'aerospike_arm_runners_2' }}
     steps:
     # TODO: the checkout code is also duplicated in the macOS stage tests
     # But it's only a few lines of code so I didn't bother to create a composite action for it.
@@ -95,12 +95,6 @@ jobs:
         JFROG_PLATFORM_URL: ${{ secrets.JFROG_PLATFORM_URL }}
         JFROG_ACCESS_TOKEN: ${{ secrets.JFROG_ACCESS_TOKEN }}
         JFROG_REPO_NAME: ${{ vars.JFROG_REPO_NAME }}
-
-    - name: Set up QEMU for cross compiling arm64
-      if: ${{ env.DISTRO_DOCKER_IMAGE_PLATFORM == 'linux/arm64' }}
-      uses: docker/setup-qemu-action@v2
-      with:
-        platforms: arm64
 
     - uses: ./.github/actions/run-ee-server
       with:

--- a/.github/workflows/test-server-rc.yml
+++ b/.github/workflows/test-server-rc.yml
@@ -13,7 +13,6 @@ on:
 
 jobs:
   manylinux:
-    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -26,20 +25,14 @@ jobs:
           ["3.12", "cp312"]
         ]
         platform: [
-          "x86_64",
-          "aarch64"
+          ["x86_64", "ubuntu-22.04"],
+          ["aarch64", "aerospike_arm_runners_2"]
         ]
-
+    runs-on: ${{ matrix.platform[1] }}
     steps:
     - uses: actions/checkout@v4
 
-    - name: Set up QEMU for cross compiling arm64
-      if: ${{ matrix.platform == 'aarch64' }}
-      uses: docker/setup-qemu-action@v2
-      with:
-        platforms: arm64
-
-    - run: docker run -d --name manylinux quay.io/pypa/manylinux2014_${{ matrix.platform }} tail -f /dev/null
+    - run: docker run -d --name manylinux quay.io/pypa/manylinux2014_${{ matrix.platform[0] }} tail -f /dev/null
 
     - uses: ./.github/actions/run-ee-server-for-ext-container
       with:
@@ -50,7 +43,7 @@ jobs:
 
     - uses: actions/download-artifact@v4
       with:
-        name: ${{ matrix.python[1] }}-manylinux_${{ matrix.platform }}.build
+        name: ${{ matrix.python[1] }}-manylinux_${{ matrix.platform[0] }}.build
         path: ./
 
     - name: Copy repo and wheel into manylinux container


### PR DESCRIPTION
Build wheels:
https://github.com/aerospike/aerospike-client-python/actions/runs/9881629015

Stage tests run 3 times to make sure ARM jobs pass consistently:
1-2. https://github.com/aerospike/aerospike-client-python/actions/runs/9882439609
3. https://github.com/aerospike/aerospike-client-python/actions/runs/9883470808

dev-workflow-p1: https://github.com/aerospike/aerospike-client-python/actions/runs/9894525911/job/27332464333