### PR TITLE
Fix code example

### DIFF
--- a/doc/aerospike.rst
+++ b/doc/aerospike.rst
@@ -324,7 +324,7 @@ Other
     .. code-block:: python
 
         import aerospike
-        import pprint
+        import pprint as pp
 
         digest = aerospike.calc_digest("test", "demo", 1 )
         pp.pprint(digest)


### PR DESCRIPTION
The current code example produces error:

```
root@d1716cafa3fb:/app# cat script.py
import aerospike
import pprint

digest = aerospike.calc_digest("test", "demo", 1 )
pp.pprint(digest)
root@d1716cafa3fb:/app# python script.py
Traceback (most recent call last):
  File "/app/script.py", line 5, in <module>
    pp.pprint(digest)
    ^^
NameError: name 'pp' is not defined
root@d1716cafa3fb:/app#
```

With this fix it works:

```
root@d1716cafa3fb:/app# cat script.py
import aerospike
import pprint as pp

digest = aerospike.calc_digest("test", "demo", 1 )
pp.pprint(digest)
root@d1716cafa3fb:/app# python script.py
bytearray(b'\xb7\xf4\xb88\x89\xe2\xdag\xdeh>\x1d\xf6\x91\x9a\x1e\xac\xc4F\xc8')
root@d1716cafa3fb:/app#
```