### PR TITLE
[DEVOPS-255] CI/CD: Use setup-python action to install Python on Windows self-hosted runners

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -508,7 +508,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python[2] }}
+          python-version: ${{ matrix.python[1] }}
 
       - name: Install wheel
         run: python${{ matrix.python[1] }} -m pip install aerospike --force-reinstall --no-index --find-links=./

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -511,19 +511,19 @@ jobs:
           python-version: ${{ matrix.python[1] }}
 
       - name: Install wheel
-        run: python${{ matrix.python[1] }} -m pip install aerospike --force-reinstall --no-index --find-links=./
+        run: python3 -m pip install aerospike --force-reinstall --no-index --find-links=./
       - name: Connect to Docker container on remote machine with Docker daemon
         # DOCKER_HOST contains the IP address of the remote machine
         run: |
-          python${{ matrix.python[1] }} -m pip install crudini==0.9.4
+          python3 -m pip install crudini==0.9.4
           $env:DOCKER_HOST_IP = $env:DOCKER_HOST | foreach {$_.replace("tcp://","")} | foreach {$_.replace(":2375", "")}
-          python${{ matrix.python[1] }} -m crudini --set config.conf community-edition hosts ${env:DOCKER_HOST_IP}:3000
+          python3 -m crudini --set config.conf community-edition hosts ${env:DOCKER_HOST_IP}:3000
         working-directory: test
 
-      - run: python${{ matrix.python[1] }} -m pip install pytest -c requirements.txt
+      - run: python3 -m pip install pytest -c requirements.txt
         working-directory: test
 
-      - run: python${{ matrix.python[1] }} -m pytest new_tests/
+      - run: python3 -m pytest new_tests/
         working-directory: test
 
       - name: Cleanup

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -506,6 +506,10 @@ jobs:
         run: cp config.conf.template config.conf
         working-directory: test
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python[2] }}
+
       - name: Install wheel
         run: python${{ matrix.python[1] }} -m pip install aerospike --force-reinstall --no-index --find-links=./
       - name: Connect to Docker container on remote machine with Docker daemon


### PR DESCRIPTION
First run (installs Python for first time): https://github.com/aerospike/aerospike-client-python/actions/runs/10152681659/job/28074723508
Rerun (uses cached setup-python installs): https://github.com/aerospike/aerospike-client-python/actions/runs/10152790089