### PR TITLE
[CLIENT-3063] CI/CD: Run enterprise edition tests on wheels built for Mac arm64 (M1)

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -345,7 +345,7 @@ jobs:
     - run: security unlock-keychain -p ${{ secrets.MAC_M1_SELF_HOSTED_RUNNER_PW }}
       if: ${{ inputs.run_tests && inputs.use-server-rc }}
 
-    - uses: ./.github/actions/run-ee-server-for-ext-container
+    - uses: ./.github/actions/run-ee-server
       if: ${{ inputs.run_tests }}
       with:
         use-server-rc: ${{ inputs.use-server-rc }}

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -345,23 +345,13 @@ jobs:
     - run: security unlock-keychain -p ${{ secrets.MAC_M1_SELF_HOSTED_RUNNER_PW }}
       if: ${{ inputs.run_tests && inputs.use-server-rc }}
 
-    - if: ${{ inputs.run_tests && inputs.use-server-rc }}
-      uses: docker/login-action@v3
-      with:
-        username: ${{ secrets.DOCKER_HUB_BOT_USERNAME }}
-        password: ${{ secrets.DOCKER_HUB_BOT_PW }}
-
-    - name: Use server rc
-      if: ${{ inputs.run_tests && inputs.use-server-rc }}
-      run: echo IMAGE_NAME="${{ vars.SERVER_RC_REPO_LINK }}:${{ inputs.server-tag }}" >> $GITHUB_ENV
-
-    - name: Use server release
-      if: ${{ inputs.run_tests && !inputs.use-server-rc }}
-      run: echo IMAGE_NAME="${{ vars.SERVER_REPO_LINK }}:${{ inputs.server-tag }}" >> $GITHUB_ENV
-
-    - name: Run server
+    - uses: ./.github/actions/run-ee-server-for-ext-container
       if: ${{ inputs.run_tests }}
-      run: docker run -d -p 3000:3000 --pull always --name aerospike ${{ env.IMAGE_NAME }}
+      with:
+        use-server-rc: ${{ inputs.use-server-rc }}
+        server-tag: ${{ inputs.server-tag }}
+        docker-hub-username: ${{ secrets.DOCKER_HUB_BOT_USERNAME }}
+        docker-hub-password: ${{ secrets.DOCKER_HUB_BOT_PW }}
 
     - name: Set unoptimize flag
       if: ${{ inputs.apply-no-optimizations }}
@@ -376,10 +366,6 @@ jobs:
     - name: Install delocate
       run: python${{ matrix.python-version[1] }} -m pip install --break-system-packages --force-reinstall delocate -c ./requirements.txt
       working-directory: .github/workflows
-
-    - name: Create config.conf
-      run: cp config.conf.template config.conf
-      working-directory: test
 
     - run: delocate-wheel --require-archs "arm64" -w wheelhouse/ -v dist/*.whl
     - run: python${{ matrix.python-version[1] }} -m pip install --break-system-packages --find-links=wheelhouse/ --no-index --force-reinstall aerospike


### PR DESCRIPTION
- EE tests pass on Mac M1
- setup buildx action works on Mac M1 self hosted

Mac M1 tests pass twice: https://github.com/aerospike/aerospike-client-python/actions/runs/10219987761

TODO: next week I need to ensure that the Mac M1 runners are reset to a clean slate after each job