### PR TITLE
[CLIENT-3106] Fix reference count error caused by not properly incrementing reference count for Py_None object

### DIFF
--- a/src/main/exception.c
+++ b/src/main/exception.c
@@ -321,6 +321,7 @@ PyObject *AerospikeException_New(void)
 
         PyObject *py_code = NULL;
         if (exception_def.code == NO_ERROR_CODE) {
+            Py_INCREF(Py_None);
             py_code = Py_None;
         }
         else {


### PR DESCRIPTION
None's reference count needs to be managed properly for Python 3.11 and lower

https://docs.python.org/3.11/c-api/none.html#c.Py_None
https://docs.python.org/3.12/c-api/none.html#c.Py_None

Massif memory usage seems ok: https://github.com/aerospike/aerospike-client-python/actions/runs/10887384965/job/30209613022
No memory errors from valgrind: https://github.com/aerospike/aerospike-client-python/actions/runs/10887382672

Build wheels macOS x86 tests fail fast even though I disabled that. Have to investigate later, but besides that, it should be fine