### PR TITLE
macOS x86: Replace the default VM type (QEMU) with vz when starting up colima

### DIFF
--- a/.github/actions/setup-docker-on-macos/action.yml
+++ b/.github/actions/setup-docker-on-macos/action.yml
@@ -13,5 +13,5 @@ runs:
     shell: bash
 
   - name: Start Docker Engine
-    run: colima start
+    run: colima start --vm-type vz
     shell: bash

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -145,7 +145,7 @@ jobs:
         declare -A hashmap
         hashmap[manylinux_x86_64]="ubuntu-22.04"
         hashmap[manylinux_aarch64]="aerospike_arm_runners_2"
-        hashmap[macosx_x86_64]="macos-12-large"
+        hashmap[macosx_x86_64]="macos-13"
         hashmap[macosx_arm64]="macos-14"
         hashmap[win_amd64]="windows-2022"
         echo runner_os=${hashmap[${{ inputs.platform-tag }}]} >> $GITHUB_OUTPUT


### PR DESCRIPTION
One of the macos x86 jobs still hangs and eventually fails without any logs showing up