### PR TITLE
[CLIENT-3264] Add on_locking_only option for write, apply, operate, batch_write, and batch_apply policies

### DIFF
--- a/doc/client.rst
+++ b/doc/client.rst
@@ -1572,6 +1572,17 @@ The metadata dictionary has the following key-value pairs:
 Policies
 ========
 
+.. |on_locking_only| **on_locking_only** (:class:`bool`)
+
+    Execute the write command only if the record is not already locked by this transaction.
+    If this field is true and the record is already locked by this transaction, the command will
+    raise an Aerospike exception with server error code ``AEROSPIKE_MRT_ALREADY_LOCKED`` (``126``).
+
+    This field is useful for safely retrying non-idempotent writes as an alternative to simply
+    aborting the transaction.
+
+    Default: :py:obj:`False`
+
 .. _aerospike_write_policies:
 
 Write Policies
@@ -1674,7 +1685,7 @@ Write Policies
 
             Default: :py:obj:`None`
 
-        * .. include:: ./on_locking_only.rst
+        * |on_locking_only|
 
 .. _aerospike_read_policies:
 

--- a/doc/client.rst
+++ b/doc/client.rst
@@ -1572,17 +1572,6 @@ The metadata dictionary has the following key-value pairs:
 Policies
 ========
 
-.. |on_locking_only| replace:: **on_locking_only** (:class:`bool`)
-
-    Execute the write command only if the record is not already locked by this transaction.
-    If this field is true and the record is already locked by this transaction, the command will
-    raise an Aerospike exception with server error code ``AEROSPIKE_MRT_ALREADY_LOCKED`` (``126``).
-
-    This field is useful for safely retrying non-idempotent writes as an alternative to simply
-    aborting the transaction.
-
-    Default: :py:obj:`False`
-
 .. _aerospike_write_policies:
 
 Write Policies
@@ -1685,7 +1674,7 @@ Write Policies
 
             Default: :py:obj:`None`
 
-        * |on_locking_only|
+        * .. include:: ./on_locking_only.rst
 
 .. _aerospike_read_policies:
 

--- a/doc/client.rst
+++ b/doc/client.rst
@@ -1669,10 +1669,7 @@ Write Policies
 
             Default: :data:`aerospike.POLICY_REPLICA_SEQUENCE`
 
-        * **txn** :class:`aerospike.Transaction`
-            Multi-record command identifier.
-
-            Default: :py:obj:`None`
+        * .. include:: ./txn.rst
 
         * .. include:: ./on_locking_only.rst
 
@@ -1777,10 +1774,7 @@ Read Policies
 
             .. note:: Requires Aerospike server version >= 5.2.
 
-        * **txn** :class:`aerospike.Transaction`
-            Multi-record command identifier.
-
-            Default: :py:obj:`None`
+        * .. include:: ./txn.rst
 
 .. _aerospike_operate_policies:
 
@@ -1911,10 +1905,7 @@ Operate Policies
             | Default: None
 
             .. note:: Requires Aerospike server version >= 5.2.
-        * **txn** :class:`aerospike.Transaction`
-            Multi-record command identifier.
-
-            Default: :py:obj:`None`
+        * .. include:: ./txn.rst
 
         * .. include:: ./on_locking_only.rst
 
@@ -1997,10 +1988,8 @@ Apply Policies
             | Default: None
 
             .. note:: Requires Aerospike server version >= 5.2.
-        * **txn** :class:`aerospike.Transaction`
-            Multi-record command identifier.
 
-            Default: :py:obj:`None`
+        * .. include:: ./txn.rst
 
         * .. include:: ./on_locking_only.rst
 
@@ -2087,10 +2076,8 @@ Remove Policies
             | Default: None
 
             .. note:: Requires Aerospike server version >= 5.2.
-        * **txn** :class:`aerospike.Transaction`
-            Multi-record command identifier.
 
-            Default: :py:obj:`None`
+        * .. include:: ./txn.rst
 
 .. _aerospike_batch_policies:
 
@@ -2225,10 +2212,8 @@ Batch Policies
             Server versions < 6.0 do not support this field and treat this value as false for key specific errors.
 
             Default: ``True``
-        * **txn** :class:`aerospike.Transaction`
-            Multi-record command identifier.
 
-            Default: :py:obj:`None`
+        * .. include:: ./txn.rst
 
 .. _aerospike_batch_write_policies:
 

--- a/doc/client.rst
+++ b/doc/client.rst
@@ -1674,6 +1674,8 @@ Write Policies
 
             Default: :py:obj:`None`
 
+        * .. include:: ./on_locking_only.rst
+
 .. _aerospike_read_policies:
 
 Read Policies

--- a/doc/client.rst
+++ b/doc/client.rst
@@ -1674,7 +1674,7 @@ Write Policies
 
             Default: :py:obj:`None`
 
-        * .. include:: ./on_locking_only.rst
+        .. include:: ./on_locking_only.rst
 
 .. _aerospike_read_policies:
 

--- a/doc/client.rst
+++ b/doc/client.rst
@@ -1674,7 +1674,7 @@ Write Policies
 
             Default: :py:obj:`None`
 
-        .. include:: ./on_locking_only.rst
+        * .. include:: ./on_locking_only.rst
 
 .. _aerospike_read_policies:
 

--- a/doc/client.rst
+++ b/doc/client.rst
@@ -1916,6 +1916,8 @@ Operate Policies
 
             Default: :py:obj:`None`
 
+        * .. include:: ./on_locking_only.rst
+
 .. _aerospike_apply_policies:
 
 Apply Policies
@@ -2000,6 +2002,7 @@ Apply Policies
 
             Default: :py:obj:`None`
 
+        * .. include:: ./on_locking_only.rst
 
 .. _aerospike_remove_policies:
 
@@ -2280,6 +2283,8 @@ Batch Write Policies
 
             Default: ``0``
 
+        * .. include:: ./on_locking_only.rst
+
 .. _aerospike_batch_apply_policies:
 
 Batch Apply Policies
@@ -2316,6 +2321,8 @@ Batch Apply Policies
             | Compiled aerospike expressions :mod:`aerospike_helpers` used for filtering records within a command.
             |
             | Default: None
+
+        * .. include:: ./on_locking_only.rst
 
 .. _aerospike_batch_remove_policies:
 

--- a/doc/client.rst
+++ b/doc/client.rst
@@ -1572,7 +1572,7 @@ The metadata dictionary has the following key-value pairs:
 Policies
 ========
 
-.. |on_locking_only| **on_locking_only** (:class:`bool`)
+.. |on_locking_only| replace:: **on_locking_only** (:class:`bool`)
 
     Execute the write command only if the record is not already locked by this transaction.
     If this field is true and the record is already locked by this transaction, the command will

--- a/doc/on_locking_only.rst
+++ b/doc/on_locking_only.rst
@@ -1,5 +1,7 @@
 **on_locking_only** (:class:`bool`)
 
+    NOTE: this policy only works for transaction level policies, not config level policies.
+
     Execute the write command only if the record is not already locked by this transaction.
     If this field is true and the record is already locked by this transaction, the command will
     raise an Aerospike exception with server error code ``AEROSPIKE_MRT_ALREADY_LOCKED`` (``126``).

--- a/doc/on_locking_only.rst
+++ b/doc/on_locking_only.rst
@@ -1,0 +1,10 @@
+* **on_locking_only** (:class:`bool`)
+
+    Execute the write command only if the record is not already locked by this transaction.
+    If this field is true and the record is already locked by this transaction, the command will
+    raise an Aerospike exception with server error code ``AEROSPIKE_MRT_ALREADY_LOCKED`` (``126``).
+
+    This field is useful for safely retrying non-idempotent writes as an alternative to simply
+    aborting the transaction.
+
+    Default: :py:obj:`False`

--- a/doc/on_locking_only.rst
+++ b/doc/on_locking_only.rst
@@ -1,4 +1,4 @@
-* **on_locking_only** (:class:`bool`)
+**on_locking_only** (:class:`bool`)
 
     Execute the write command only if the record is not already locked by this transaction.
     If this field is true and the record is already locked by this transaction, the command will

--- a/doc/txn.rst
+++ b/doc/txn.rst
@@ -1,5 +1,7 @@
 **txn** :class:`aerospike.Transaction`
 
+    NOTE: this policy only works for transaction level policies, not config level policies.
+
     Multi-record command identifier.
 
     Default: :py:obj:`None`

--- a/doc/txn.rst
+++ b/doc/txn.rst
@@ -1,4 +1,5 @@
 **txn** :class:`aerospike.Transaction`
+
     Multi-record command identifier.
 
     Default: :py:obj:`None`

--- a/doc/txn.rst
+++ b/doc/txn.rst
@@ -1,0 +1,4 @@
+**txn** :class:`aerospike.Transaction`
+    Multi-record command identifier.
+
+    Default: :py:obj:`None`

--- a/doc/txn.rst
+++ b/doc/txn.rst
@@ -1,4 +1,4 @@
-**txn** :class:`aerospike.Transaction`
+**txn** (:class:`aerospike.Transaction`)
 
     NOTE: this policy only works for transaction level policies, not config level policies.
 

--- a/src/main/policy.c
+++ b/src/main/policy.c
@@ -354,6 +354,7 @@ as_status pyobject_to_policy_apply(AerospikeClient *self, as_error *err,
         POLICY_SET_FIELD(commit_level, as_policy_commit_level);
         POLICY_SET_FIELD(durable_delete, bool);
         POLICY_SET_FIELD(ttl, uint32_t);
+        POLICY_SET_FIELD(on_locking_only, bool);
     }
 
     // Update the policy
@@ -593,6 +594,7 @@ as_status pyobject_to_policy_write(AerospikeClient *self, as_error *err,
         POLICY_SET_FIELD(durable_delete, bool);
         POLICY_SET_FIELD(replica, as_policy_replica);
         POLICY_SET_FIELD(compression_threshold, uint32_t);
+        POLICY_SET_FIELD(on_locking_only, bool);
     }
 
     // Update the policy
@@ -637,6 +639,7 @@ as_status pyobject_to_policy_operate(AerospikeClient *self, as_error *err,
         POLICY_SET_FIELD(deserialize, bool);
         POLICY_SET_FIELD(exists, as_policy_exists);
         POLICY_SET_FIELD(read_touch_ttl_percent, int);
+        POLICY_SET_FIELD(on_locking_only, bool);
 
         // 4.0.0 new policies
         POLICY_SET_FIELD(read_mode_ap, as_policy_read_mode_ap);
@@ -712,6 +715,7 @@ as_status pyobject_to_batch_write_policy(AerospikeClient *self, as_error *err,
     POLICY_SET_FIELD(gen, as_policy_gen);
     POLICY_SET_FIELD(exists, as_policy_exists);
     POLICY_SET_FIELD(durable_delete, bool);
+    POLICY_SET_FIELD(on_locking_only, bool);
 
     // C client 5.0 new expressions
     POLICY_SET_EXPRESSIONS_FIELD();
@@ -759,6 +763,7 @@ as_status pyobject_to_batch_apply_policy(AerospikeClient *self, as_error *err,
     POLICY_SET_FIELD(commit_level, as_policy_commit_level);
     POLICY_SET_FIELD(ttl, uint32_t);
     POLICY_SET_FIELD(durable_delete, bool);
+    POLICY_SET_FIELD(on_locking_only, bool);
 
     // C client 5.0 new expressions
     POLICY_SET_EXPRESSIONS_FIELD();


### PR DESCRIPTION
Valgrind shows no memory errors. Massif memory usage looks ok
Build artifacts passes

Doc changes

https://aerospike-python-client--713.org.readthedocs.build/en/713/client.html#write-policies

Extra changes:
- Add note that the "txn" field only works for transaction level policies

Misc notes:
- Missing gray background behind "txn" and "on_locking_only" policy names, but I don't think this is a big deal
- Discussed with Brian Nichols and I decided to only allow on_locking_only for transaction level policies. I only think users would only set MRTs using transaction level policies.