### PR TITLE
[CLIENT-3121] Add "txn_verify" and "txn_roll" config policies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -359,7 +359,7 @@ jobs:
       run: pip install -r test/requirements.txt
 
     - name: Run lowest supported server
-      run: docker run -d --name aerospike -p 3000-3002:3000-3002 -e DEFAULT_TTL=2592000 aerospike/aerospike-server:6.3
+      run: docker run -d --name aerospike -p 3000-3002:3000-3002 -e DEFAULT_TTL=2592000 aerospike/aerospike-server:${{ vars.LOWEST_SUPPORTED_SERVER_VERSION }}
 
     - name: Create config.conf
       run: cp config.conf.template config.conf

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,7 +84,7 @@ jobs:
       run: echo WHEEL_GH_ARTIFACT_NAME=${{ env.WHEEL_GH_ARTIFACT_NAME }}-sanitizer >> $GITHUB_ENV
 
     - name: Send wheel to test jobs
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ env.WHEEL_GH_ARTIFACT_NAME }}
         path: ./dist/*.whl
@@ -167,7 +167,7 @@ jobs:
 
     - name: Upload coverage report folder to Github
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: coverage-report
         path: build/temp*/src/main/
@@ -181,7 +181,7 @@ jobs:
       with:
         submodules: recursive
 
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: coverage-report
         path: ./coverage-report
@@ -207,7 +207,7 @@ jobs:
         python-version: ${{ env.LOWEST_SUPPORTED_PY_VERSION }}
         architecture: 'x64'
 
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: wheel-${{ env.LOWEST_SUPPORTED_PY_VERSION }}
 
@@ -235,7 +235,7 @@ jobs:
         python-version: ${{ env.LOWEST_SUPPORTED_PY_VERSION }}
         architecture: 'x64'
 
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: wheel-${{ env.LOWEST_SUPPORTED_PY_VERSION }}
 
@@ -294,7 +294,7 @@ jobs:
     - if: ${{ matrix.sanitizer }}
       run: echo WHEEL_GH_ARTIFACT_NAME=${{ env.WHEEL_GH_ARTIFACT_NAME }}-sanitizer >> $GITHUB_ENV
 
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: ${{ env.WHEEL_GH_ARTIFACT_NAME }}
 
@@ -348,7 +348,7 @@ jobs:
         python-version: ${{ env.LOWEST_SUPPORTED_PY_VERSION }}
         architecture: 'x64'
 
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: wheel-${{ env.LOWEST_SUPPORTED_PY_VERSION }}
 
@@ -386,7 +386,7 @@ jobs:
         python-version: ${{ env.LOWEST_SUPPORTED_PY_VERSION }}
         architecture: 'x64'
 
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: wheel-${{ env.LOWEST_SUPPORTED_PY_VERSION }}
 
@@ -458,7 +458,7 @@ jobs:
       with:
         python-version: ${{ env.LOWEST_SUPPORTED_PY_VERSION }}
         architecture: 'x64'
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: wheel-${{ env.LOWEST_SUPPORTED_PY_VERSION }}
     - run: python3 -m pip install *.whl

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -359,7 +359,7 @@ jobs:
       run: pip install -r test/requirements.txt
 
     - name: Run lowest supported server
-      run: docker run -d --name aerospike -p 3000-3002:3000-3002 -e DEFAULT_TTL=2592000 aerospike/aerospike-server:6.2
+      run: docker run -d --name aerospike -p 3000-3002:3000-3002 -e DEFAULT_TTL=2592000 aerospike/aerospike-server:6.3
 
     - name: Create config.conf
       run: cp config.conf.template config.conf

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -359,7 +359,7 @@ jobs:
       run: pip install -r test/requirements.txt
 
     - name: Run lowest supported server
-      run: docker run -d --name aerospike -p 3000-3002:3000-3002 -e DEFAULT_TTL=2592000 aerospike/aerospike-server:${{ vars.LOWEST_SUPPORTED_SERVER_VERSION }}
+      run: docker run -d --name aerospike -p 3000-3002:3000-3002 -e DEFAULT_TTL=2592000 aerospike/aerospike-server:6.2
 
     - name: Create config.conf
       run: cp config.conf.template config.conf

--- a/doc/aerospike.rst
+++ b/doc/aerospike.rst
@@ -406,6 +406,11 @@ Only the `hosts` key is required; the rest of the keys are optional.
                 Contains :ref:`aerospike_info_policies`.
             * **admin** (:class:`dict`)
                 Contains :ref:`aerospike_admin_policies`.
+            * **txn_verify** (:class:`dict`)
+                Default transaction policy when verifying record versions in a batch. Contains :ref:`aerospike_batch_policies`.
+            * **txn_roll** (:class:`dict`)
+                Default transaction policy when rolling the transaction records forward (commit) or back (abort) in a batch.
+                Contains :ref:`aerospike_batch_policies`.
             * **total_timeout** (:class:`int`)
                 **Deprecated**: set this individually in the :ref:`aerospike_policies` dictionaries.
 

--- a/src/main/policy_config.c
+++ b/src/main/policy_config.c
@@ -137,6 +137,20 @@ as_status set_subpolicies(as_config *config, PyObject *py_policies)
         return set_policy_status;
     }
 
+    const char *batch_policy_names[] = {"txn_verify", "txn_roll"};
+    as_policy_batch *batch_policies[] = {&config->policies.txn_verify,
+                                         &config->policies.txn_roll};
+    for (int i = 0;
+         i < sizeof(batch_policy_names) / sizeof(batch_policy_names[0]); i++) {
+        PyObject *py_batch_policy =
+            PyDict_GetItemString(py_policies, batch_policy_names[i]);
+        set_policy_status =
+            set_batch_policy(batch_policies[i], batch_parent_write_policy);
+        if (set_policy_status != AEROSPIKE_OK) {
+            return set_policy_status;
+        }
+    }
+
     return AEROSPIKE_OK;
 }
 

--- a/src/main/policy_config.c
+++ b/src/main/policy_config.c
@@ -140,7 +140,7 @@ as_status set_subpolicies(as_config *config, PyObject *py_policies)
     const char *batch_policy_names[] = {"txn_verify", "txn_roll"};
     as_policy_batch *batch_policies[] = {&config->policies.txn_verify,
                                          &config->policies.txn_roll};
-    for (int i = 0;
+    for (unsigned long i = 0;
          i < sizeof(batch_policy_names) / sizeof(batch_policy_names[0]); i++) {
         PyObject *py_batch_policy =
             PyDict_GetItemString(py_policies, batch_policy_names[i]);

--- a/src/main/policy_config.c
+++ b/src/main/policy_config.c
@@ -145,7 +145,7 @@ as_status set_subpolicies(as_config *config, PyObject *py_policies)
         PyObject *py_batch_policy =
             PyDict_GetItemString(py_policies, batch_policy_names[i]);
         set_policy_status =
-            set_batch_policy(batch_policies[i], batch_parent_write_policy);
+            set_batch_policy(batch_policies[i], py_batch_policy);
         if (set_policy_status != AEROSPIKE_OK) {
             return set_policy_status;
         }

--- a/test/new_tests/test_new_constructor.py
+++ b/test/new_tests/test_new_constructor.py
@@ -201,7 +201,7 @@ def test_setting_batch_remove_gen_neg_value():
 
 def test_setting_batch_policies():
     config = copy.deepcopy(gconfig)
-    policies = ["batch_remove", "batch_apply", "batch_write", "batch_parent_write"]
+    policies = ["batch_remove", "batch_apply", "batch_write", "batch_parent_write", "txn_verify", "txn_roll"]
     for policy in policies:
         config["policies"][policy] = {}
     aerospike.client(config)


### PR DESCRIPTION
https://aerospike-python-client--715.org.readthedocs.build/en/715/aerospike.html#client-configuration

Valgrind shows no memory errors, massif memory usage looks ok, build artifacts passes
Test on lowest supported server failing due to C client bug, will be fixed in a future C client revision

Extra changes:

CI/CD: Update upload-artifact and download-artifact from v3 to v4 to fix workflows not running