### PR TITLE
[CLIENT-3307] Fix stack overflow when sending a batch command with many keys

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,4 +2,4 @@
 	path = aerospike-client-c
 	# url = git@github.com:aerospike/aerospike-client-c.git
 	url = https://github.com/aerospike/aerospike-client-c.git
-	branch = stage
+	branch = CLIENT-3307


### PR DESCRIPTION
Fix was verified by running this test with valgrind: https://github.com/citrusleaf/devtools/tree/master/aerolab/core/batch-client-crash

Valgrind shows no memory errors.
Massif memory usage looks normal
Build artifacts passes