### PR TITLE
[CLIENT-3382] Fix 2 memory leaks in client.batch_write()

### DIFF
--- a/src/main/client/batch_write.c
+++ b/src/main/client/batch_write.c
@@ -173,7 +173,9 @@ static PyObject *AerospikeClient_BatchWriteInvoke(AerospikeClient *self,
         as_error_update(err, AEROSPIKE_ERR_PARAM,
                         "%s must be a list of BatchRecord",
                         FIELD_NAME_BATCH_RECORDS);
-        // TODO: mem leak if py_batch_records is not the right class
+        if (py_batch_records) {
+            Py_DECREF(py_batch_records);
+        }
         goto CLEANUP4;
     }
 
@@ -246,8 +248,8 @@ static PyObject *AerospikeClient_BatchWriteInvoke(AerospikeClient *self,
                                 "py_ops_list is NULL or not a list, %s must be "
                                 "a list of aerospike operation dicts",
                                 FIELD_NAME_BATCH_OPS);
-
-                // TODO: mem leak if ops is not a list
+                // TODO: mem leak if ops is not a list?
+                // Fix later
                 goto CLEANUP1;
             }
 

--- a/test/new_tests/test_batch_write.py
+++ b/test/new_tests/test_batch_write.py
@@ -401,6 +401,14 @@ class TestBatchWrite(TestBaseClass):
                 e.ParamError,
             ),
             (
+                "bad-batch-record-batch_records-field",
+                br.BatchRecords(
+                    1
+                ),
+                {},
+                e.ParamError,
+            ),
+            (
                 "bad-batch-record-key",
                 br.BatchRecords(
                     [


### PR DESCRIPTION
Still potential memory leaks in batch_write(), but need to ship this fix ASAP for a customer.
Will rebase and merge on approval

Manual Testing
Build artifacts passes except noise
valgrind shows no memory errors, massif mem usage looks ok
Leak is gone now when running support team's script

Extra changes:
- Rename label so it is easier to understand when the label is used