### PR TITLE
[CLIENT-3411] Fix client config's "batch" policy being used in client.batch_{write,remove,apply}() by default instead of "batch_parent_write" when None is passed to "policy_batch" parameter

### DIFF
--- a/src/main/client/batch_apply.c
+++ b/src/main/client/batch_apply.c
@@ -356,6 +356,11 @@ PyObject *AerospikeClient_Batch_Apply(AerospikeClient *self, PyObject *args,
         goto error;
     }
 
+    if (py_policy_batch == Py_None) {
+        // Let C client choose the client config policy to use
+        py_policy_batch = NULL;
+    }
+
     py_results = AerospikeClient_Batch_Apply_Invoke(
         self, &err, py_keys, py_mod, py_func, py_args, py_policy_batch,
         py_policy_batch_apply);

--- a/src/main/client/batch_apply.c
+++ b/src/main/client/batch_apply.c
@@ -181,7 +181,7 @@ static PyObject *AerospikeClient_Batch_Apply_Invoke(
     if (py_policy_batch) {
         if (pyobject_to_policy_batch(
                 self, err, py_policy_batch, &policy_batch, &policy_batch_p,
-                &self->as->config.policies.batch_parent_write, &batch_exp_list,
+                &self->as->config.policies.batch, &batch_exp_list,
                 &batch_exp_list_p) != AEROSPIKE_OK) {
             goto CLEANUP;
         }

--- a/src/main/client/batch_apply.c
+++ b/src/main/client/batch_apply.c
@@ -311,7 +311,7 @@ PyObject *AerospikeClient_Batch_Apply(AerospikeClient *self, PyObject *args,
                                       PyObject *kwds)
 {
     as_error err;
-    PyObject *py_policy_batch = Py_None;
+    PyObject *py_policy_batch = NULL;
     PyObject *py_policy_batch_apply = NULL;
     PyObject *py_keys = NULL;
     PyObject *py_mod = NULL;

--- a/src/main/client/batch_apply.c
+++ b/src/main/client/batch_apply.c
@@ -311,7 +311,7 @@ PyObject *AerospikeClient_Batch_Apply(AerospikeClient *self, PyObject *args,
                                       PyObject *kwds)
 {
     as_error err;
-    PyObject *py_policy_batch = NULL;
+    PyObject *py_policy_batch = Py_None;
     PyObject *py_policy_batch_apply = NULL;
     PyObject *py_keys = NULL;
     PyObject *py_mod = NULL;

--- a/src/main/client/batch_apply.c
+++ b/src/main/client/batch_apply.c
@@ -181,7 +181,7 @@ static PyObject *AerospikeClient_Batch_Apply_Invoke(
     if (py_policy_batch) {
         if (pyobject_to_policy_batch(
                 self, err, py_policy_batch, &policy_batch, &policy_batch_p,
-                &self->as->config.policies.batch, &batch_exp_list,
+                &self->as->config.policies.batch_parent_write, &batch_exp_list,
                 &batch_exp_list_p) != AEROSPIKE_OK) {
             goto CLEANUP;
         }

--- a/src/main/client/batch_operate.c
+++ b/src/main/client/batch_operate.c
@@ -373,6 +373,11 @@ PyObject *AerospikeClient_Batch_Operate(AerospikeClient *self, PyObject *args,
         goto error;
     }
 
+    if (py_policy_batch == Py_None) {
+        // Let C client choose the client config policy to use
+        py_policy_batch = NULL;
+    }
+
     if (py_ttl && py_ttl != Py_None && !PyLong_Check(py_ttl)) {
         as_error_update(&err, AEROSPIKE_ERR_PARAM, "ttl should be an integer");
         goto error;

--- a/src/main/client/batch_remove.c
+++ b/src/main/client/batch_remove.c
@@ -315,6 +315,11 @@ PyObject *AerospikeClient_Batch_Remove(AerospikeClient *self, PyObject *args,
         goto error;
     }
 
+    if (py_policy_batch == Py_None) {
+        // Let C client choose the client config policy to use
+        py_policy_batch = NULL;
+    }
+
     py_results = AerospikeClient_Batch_Remove_Invoke(
         self, &err, py_keys, py_policy_batch, py_policy_batch_remove);
 

--- a/src/main/client/batch_remove.c
+++ b/src/main/client/batch_remove.c
@@ -292,7 +292,7 @@ PyObject *AerospikeClient_Batch_Remove(AerospikeClient *self, PyObject *args,
                                        PyObject *kwds)
 {
     as_error err;
-    PyObject *py_policy_batch = NULL;
+    PyObject *py_policy_batch = Py_None;
     PyObject *py_policy_batch_remove = NULL;
     PyObject *py_keys = NULL;
     PyObject *py_results = NULL;

--- a/src/main/client/batch_remove.c
+++ b/src/main/client/batch_remove.c
@@ -175,7 +175,7 @@ static PyObject *AerospikeClient_Batch_Remove_Invoke(
     if (py_policy_batch) {
         if (pyobject_to_policy_batch(
                 self, err, py_policy_batch, &policy_batch, &policy_batch_p,
-                &self->as->config.policies.batch_parent_write, &batch_exp_list,
+                &self->as->config.policies.batch, &batch_exp_list,
                 &batch_exp_list_p) != AEROSPIKE_OK) {
             goto CLEANUP;
         }

--- a/src/main/client/batch_remove.c
+++ b/src/main/client/batch_remove.c
@@ -175,7 +175,7 @@ static PyObject *AerospikeClient_Batch_Remove_Invoke(
     if (py_policy_batch) {
         if (pyobject_to_policy_batch(
                 self, err, py_policy_batch, &policy_batch, &policy_batch_p,
-                &self->as->config.policies.batch, &batch_exp_list,
+                &self->as->config.policies.batch_parent_write, &batch_exp_list,
                 &batch_exp_list_p) != AEROSPIKE_OK) {
             goto CLEANUP;
         }

--- a/src/main/client/batch_remove.c
+++ b/src/main/client/batch_remove.c
@@ -292,7 +292,7 @@ PyObject *AerospikeClient_Batch_Remove(AerospikeClient *self, PyObject *args,
                                        PyObject *kwds)
 {
     as_error err;
-    PyObject *py_policy_batch = Py_None;
+    PyObject *py_policy_batch = NULL;
     PyObject *py_policy_batch_remove = NULL;
     PyObject *py_keys = NULL;
     PyObject *py_results = NULL;

--- a/src/main/client/batch_write.c
+++ b/src/main/client/batch_write.c
@@ -158,10 +158,10 @@ static PyObject *AerospikeClient_BatchWriteInvoke(AerospikeClient *self,
     }
 
     if (py_policy != NULL) {
-        if (pyobject_to_policy_batch(
-                self, err, py_policy, &batch_policy, &batch_policy_p,
-                &self->as->config.policies.batch_parent_write, &exp_list,
-                &exp_list_p) != AEROSPIKE_OK) {
+        if (pyobject_to_policy_batch(self, err, py_policy, &batch_policy,
+                                     &batch_policy_p,
+                                     &self->as->config.policies.batch,
+                                     &exp_list, &exp_list_p) != AEROSPIKE_OK) {
             goto CLEANUP4;
         }
     }

--- a/src/main/client/batch_write.c
+++ b/src/main/client/batch_write.c
@@ -158,10 +158,10 @@ static PyObject *AerospikeClient_BatchWriteInvoke(AerospikeClient *self,
     }
 
     if (py_policy != NULL) {
-        if (pyobject_to_policy_batch(self, err, py_policy, &batch_policy,
-                                     &batch_policy_p,
-                                     &self->as->config.policies.batch,
-                                     &exp_list, &exp_list_p) != AEROSPIKE_OK) {
+        if (pyobject_to_policy_batch(
+                self, err, py_policy, &batch_policy, &batch_policy_p,
+                &self->as->config.policies.batch_parent_write, &exp_list,
+                &exp_list_p) != AEROSPIKE_OK) {
             goto CLEANUP4;
         }
     }

--- a/src/main/client/batch_write.c
+++ b/src/main/client/batch_write.c
@@ -563,7 +563,7 @@ CLEANUP4:
 PyObject *AerospikeClient_BatchWrite(AerospikeClient *self, PyObject *args,
                                      PyObject *kwds)
 {
-    PyObject *py_policy = NULL;
+    PyObject *py_policy = Py_None;
     PyObject *py_batch_recs = NULL;
 
     as_error err;

--- a/src/main/client/batch_write.c
+++ b/src/main/client/batch_write.c
@@ -576,6 +576,11 @@ PyObject *AerospikeClient_BatchWrite(AerospikeClient *self, PyObject *args,
         return NULL;
     }
 
+    if (py_policy == Py_None) {
+        // Let C client choose the client config policy to use
+        py_policy = NULL;
+    }
+
     return AerospikeClient_BatchWriteInvoke(self, &err, py_policy,
                                             py_batch_recs);
 }

--- a/src/main/client/batch_write.c
+++ b/src/main/client/batch_write.c
@@ -563,7 +563,7 @@ CLEANUP4:
 PyObject *AerospikeClient_BatchWrite(AerospikeClient *self, PyObject *args,
                                      PyObject *kwds)
 {
-    PyObject *py_policy = Py_None;
+    PyObject *py_policy = NULL;
     PyObject *py_batch_recs = NULL;
 
     as_error err;

--- a/test/new_tests/test_new_constructor.py
+++ b/test/new_tests/test_new_constructor.py
@@ -202,8 +202,8 @@ def test_setting_batch_remove_gen_neg_value():
 @pytest.mark.parametrize(
     "args",
     [
-        [aerospike.Client.batch_apply, ["key1"], "module", "function", []],
-        [aerospike.Client.batch_remove, ["key"]],
+        [aerospike.Client.batch_apply, [("test", "demo", 1)], "module", "function", []],
+        [aerospike.Client.batch_remove, [("test", "demo", 1)]],
         [
             aerospike.Client.batch_write,
             br.BatchRecords(

--- a/test/new_tests/test_new_constructor.py
+++ b/test/new_tests/test_new_constructor.py
@@ -5,7 +5,7 @@ from .test_base_class import TestBaseClass
 import aerospike
 from aerospike import exception as e
 from aerospike_helpers.operations import operations
-from aerospike_helpers.batch.records import Write, BatchRecords
+from aerospike_helpers.batch import records as br
 from .test_scan_execute_background import wait_for_job_completion
 import copy
 from contextlib import nullcontext
@@ -199,6 +199,40 @@ def test_setting_batch_remove_gen_neg_value():
     assert excinfo.value.msg == "Invalid Policy setting value"
 
 
+@pytest.mark.parametrize(
+    "args",
+    [
+        [aerospike.Client.batch_apply, ["key1"], "module", "function", []],
+        [aerospike.Client.batch_remove, ["key"]],
+        [
+            aerospike.Client.batch_write,
+            br.BatchRecords(
+                batch_records=[
+                    br.Write(
+                        ("test", "demo", 1),
+                        [
+                            operations.write("ilist_bin", [2, 6]),
+                        ],
+                    )
+                ]
+            ),
+        ],
+    ]
+)
+def test_batch_parent_write(args):
+    config = copy.deepcopy(gconfig)
+    config["policies"]["batch_parent_write"] = {
+        "total_timeout": 1
+    }
+    client = aerospike.client(config)
+    api_call = args[0]
+    try:
+        with pytest.raises(e.TimeoutError):
+            api_call(client, *args[1:])
+    finally:
+        client.close()
+
+
 def test_setting_batch_policies():
     config = copy.deepcopy(gconfig)
     policies = ["batch_remove", "batch_apply", "batch_write", "batch_parent_write", "txn_verify", "txn_roll"]
@@ -297,13 +331,13 @@ class TestConfigTTL:
         ops = [
             operations.write("bin", 1)
         ]
-        batch_records = BatchRecords([
-            Write(self.key, ops=ops, meta=meta)
+        batch_records = br.BatchRecords([
+            br.Write(self.key, ops=ops, meta=meta)
         ])
         brs = self.client.batch_write(batch_records)
         # assert brs.result == 0
-        for br in brs.batch_records:
-            assert br.result == 0
+        for batch_record in brs.batch_records:
+            assert batch_record.result == 0
 
         self.check_ttl()
 
@@ -319,8 +353,8 @@ class TestConfigTTL:
         keys = [self.key]
         brs = self.client.batch_operate(keys, ops, ttl=ttl)
         # assert brs.result == 0
-        for br in brs.batch_records:
-            assert br.result == 0
+        for batch_record in brs.batch_records:
+            assert batch_record.result == 0
 
         self.check_ttl()
 

--- a/test/new_tests/test_new_constructor.py
+++ b/test/new_tests/test_new_constructor.py
@@ -228,7 +228,7 @@ def test_batch_parent_write(args):
     client = aerospike.client(config)
     api_call = args[0]
     try:
-        brs = api_call(*args[1:])
+        brs = api_call(client, *args[1:])
         assert brs.batch_records[0].result == as_errors.AEROSPIKE_ERR_TIMEOUT
     finally:
         client.close()

--- a/test/new_tests/test_new_constructor.py
+++ b/test/new_tests/test_new_constructor.py
@@ -2,6 +2,7 @@
 
 import pytest
 from .test_base_class import TestBaseClass
+from . import as_errors
 import aerospike
 from aerospike import exception as e
 from aerospike_helpers.operations import operations
@@ -227,8 +228,8 @@ def test_batch_parent_write(args):
     client = aerospike.client(config)
     api_call = args[0]
     try:
-        with pytest.raises(e.TimeoutError):
-            api_call(client, *args[1:])
+        brs = api_call(*args[1:])
+        assert brs.batch_records[0].result == as_errors.AEROSPIKE_ERR_TIMEOUT
     finally:
         client.close()
 


### PR DESCRIPTION
Build artifacts passes
Valgrind shows no memory errors or leaks
Massif memory usage looks normal

Personal notes (ignore):
- `pyobject_to_policy_*()`: `*_policy_init()` is a no-op for all code paths