### PR TITLE
[CLIENT-3478] client.batch_read(): fix memory leak if bins parameter is invalid

### DIFF
--- a/src/main/client/batch_read.c
+++ b/src/main/client/batch_read.c
@@ -300,6 +300,7 @@ CLEANUP2:
 CLEANUP1:
 
     if (err.code != AEROSPIKE_OK) {
+        Py_XDECREF(br_instance);
         raise_exception(&err);
         return NULL;
     }


### PR DESCRIPTION
Valgrind shows no memory errors and that this leak from batch_read() is now gone
Build artifacts passes when running against test_batch_read.py