### PR TITLE
[CLIENT-3497] Refactor query.where() without sindex expression changes

### DIFF
--- a/src/main/predicates.c
+++ b/src/main/predicates.c
@@ -31,6 +31,9 @@
 // Predicate tuple format:
 // (as_predicate_type, as_index_datatype, bin name, value1, value2, as_index_type)
 
+// We validate that py_bin is a unicode object when this tuple is passed to query.where()
+// If failed to create predicate, return None
+
 static PyObject *AerospikePredicates_Equals(PyObject *self, PyObject *args)
 {
     PyObject *py_bin = NULL;
@@ -67,7 +70,6 @@ static PyObject *AerospikePredicates_Contains(PyObject *self, PyObject *args)
     PyObject *py_bin = NULL;
     PyObject *py_indextype = NULL;
     PyObject *py_val = NULL;
-    int index_type;
 
     if (PyArg_ParseTuple(args, "OOO:equals", &py_bin, &py_indextype, &py_val) ==
         false) {
@@ -88,25 +90,17 @@ static PyObject *AerospikePredicates_Contains(PyObject *self, PyObject *args)
         goto exit;
     }
 
-    if (PyLong_Check(py_indextype)) {
-        index_type = PyLong_AsLong(py_indextype);
-    }
-    else {
+    if (!PyLong_Check(py_indextype)) {
         goto exit;
     }
 
-    if (PyLong_Check(py_val)) {
-        return Py_BuildValue("iiOOOi", AS_PREDICATE_EQUAL, AS_INDEX_NUMERIC,
-                             py_bin, py_val, Py_None, index_type);
-    }
-    else if (PyUnicode_Check(py_val)) {
-        return Py_BuildValue("iiOOOi", AS_PREDICATE_EQUAL, AS_INDEX_STRING,
-                             py_bin, py_val, Py_None, index_type);
-    }
-    else if (PyBytes_Check(py_val) || PyByteArray_Check(py_val)) {
+    int index_type = PyLong_AsLong(py_indextype);
+    if (PyErr_Occurred()) {
+        PyErr_Clear();
+        goto exit;
     }
 
-    return Py_BuildValue("iiOOOi", AS_PREDICATE_EQUAL, AS_INDEX_BLOB, py_bin,
+    return Py_BuildValue("iiOOOi", AS_PREDICATE_EQUAL, index_datatype, py_bin,
                          py_val, Py_None, index_type);
 
 exit:
@@ -121,24 +115,27 @@ static PyObject *AerospikePredicates_RangeContains(PyObject *self,
     PyObject *py_indextype = NULL;
     PyObject *py_min = NULL;
     PyObject *py_max = NULL;
-    int index_type;
 
     if (PyArg_ParseTuple(args, "OOOO:equals", &py_bin, &py_indextype, &py_min,
                          &py_max) == false) {
         return NULL;
     }
 
-    if (PyLong_Check(py_indextype)) {
-        index_type = PyLong_AsLong(py_indextype);
+    if (!PyLong_Check(py_indextype)) {
+        goto exit;
     }
-    else {
+    int index_type = PyLong_AsLong(py_indextype);
+    if (PyErr_Occurred()) {
+        PyErr_Clear();
         goto exit;
     }
 
-    if (PyLong_Check(py_min) && PyLong_Check(py_max)) {
-        return Py_BuildValue("iiOOOi", AS_PREDICATE_RANGE, AS_INDEX_NUMERIC,
-                             py_bin, py_min, py_max, index_type);
+    if (!PyLong_Check(py_min) || !PyLong_Check(py_max)) {
+        goto exit;
     }
+
+    return Py_BuildValue("iiOOOi", AS_PREDICATE_RANGE, AS_INDEX_NUMERIC, py_bin,
+                         py_min, py_max, index_type);
 
 exit:
     Py_INCREF(Py_None);
@@ -156,11 +153,14 @@ static PyObject *AerospikePredicates_Between(PyObject *self, PyObject *args)
         return NULL;
     }
 
-    if (PyLong_Check(py_min) && PyLong_Check(py_max)) {
-        return Py_BuildValue("iiOOO", AS_PREDICATE_RANGE, AS_INDEX_NUMERIC,
-                             py_bin, py_min, py_max);
+    if (!PyLong_Check(py_min) || !PyLong_Check(py_max)) {
+        goto exit;
     }
 
+    return Py_BuildValue("iiOOOi", AS_PREDICATE_RANGE, AS_INDEX_NUMERIC, py_bin,
+                         py_min, py_max, AS_INDEX_TYPE_DEFAULT);
+
+exit:
     Py_INCREF(Py_None);
     return Py_None;
 }
@@ -179,13 +179,21 @@ static PyObject *AerospikePredicates_GeoWithin_GeoJSONRegion(PyObject *self,
 
     if (!py_indexType) {
         py_indexType = Py_BuildValue("i", AS_INDEX_TYPE_DEFAULT);
+        if (py_indexType == NULL) {
+            goto exit;
+        }
     }
 
-    if (PyUnicode_Check(py_shape)) {
-        return Py_BuildValue("iiOOOO", AS_PREDICATE_RANGE, AS_INDEX_GEO2DSPHERE,
-                             py_bin, py_shape, Py_None, py_indexType);
+    if (!PyUnicode_Check(py_shape)) {
+        goto exit;
     }
 
+    // TODO: need to enforce index type is int or else undefined behavior
+    return Py_BuildValue("iiOOOO", AS_PREDICATE_RANGE, AS_INDEX_GEO2DSPHERE,
+                         py_bin, py_shape, Py_None, py_indexType);
+
+exit:
+    Py_XDECREF(py_indexType);
     Py_INCREF(Py_None);
     return Py_None;
 }
@@ -212,6 +220,9 @@ static PyObject *AerospikePredicates_GeoWithin_Radius(PyObject *self,
 
     if (!py_indexType) {
         py_indexType = Py_BuildValue("i", AS_INDEX_TYPE_DEFAULT);
+        if (py_indexType == NULL) {
+            goto CLEANUP;
+        }
     }
 
     py_geo_object = PyDict_New();

--- a/src/main/predicates.c
+++ b/src/main/predicates.c
@@ -188,7 +188,7 @@ static PyObject *AerospikePredicates_GeoWithin_GeoJSONRegion(PyObject *self,
         goto exit;
     }
 
-    // TODO: need to enforce index type is int or else undefined behavior
+    // We enforce the index type is an integer when where() is called
     return Py_BuildValue("iiOOOO", AS_PREDICATE_RANGE, AS_INDEX_GEO2DSPHERE,
                          py_bin, py_shape, Py_None, py_indexType);
 

--- a/src/main/predicates.c
+++ b/src/main/predicates.c
@@ -28,6 +28,9 @@
 #include "exceptions.h"
 #include "geo.h"
 
+// Predicate tuple format:
+// (as_predicate_type, as_index_datatype, bin name, value1, value2, as_index_type)
+
 static PyObject *AerospikePredicates_Equals(PyObject *self, PyObject *args)
 {
     PyObject *py_bin = NULL;
@@ -37,19 +40,24 @@ static PyObject *AerospikePredicates_Equals(PyObject *self, PyObject *args)
         return NULL;
     }
 
+    as_index_datatype index_datatype;
     if (PyLong_Check(py_val)) {
-        return Py_BuildValue("iiOO", AS_PREDICATE_EQUAL, AS_INDEX_NUMERIC,
-                             py_bin, py_val);
+        index_datatype = AS_INDEX_NUMERIC;
     }
     else if (PyUnicode_Check(py_val)) {
-        return Py_BuildValue("iiOO", AS_PREDICATE_EQUAL, AS_INDEX_STRING,
-                             py_bin, py_val);
+        index_datatype = AS_INDEX_STRING;
     }
     else if (PyBytes_Check(py_val) || PyByteArray_Check(py_val)) {
-        return Py_BuildValue("iiOO", AS_PREDICATE_EQUAL, AS_INDEX_BLOB, py_bin,
-                             py_val);
+        index_datatype = AS_INDEX_BLOB;
+    }
+    else {
+        goto error;
     }
 
+    return Py_BuildValue("iiOOOi", AS_PREDICATE_EQUAL, index_datatype, py_bin,
+                         py_val, Py_None, AS_INDEX_TYPE_DEFAULT);
+
+error:
     Py_INCREF(Py_None);
     return Py_None;
 }

--- a/src/main/predicates.c
+++ b/src/main/predicates.c
@@ -51,13 +51,13 @@ static PyObject *AerospikePredicates_Equals(PyObject *self, PyObject *args)
         index_datatype = AS_INDEX_BLOB;
     }
     else {
-        goto error;
+        goto exit;
     }
 
     return Py_BuildValue("iiOOOi", AS_PREDICATE_EQUAL, index_datatype, py_bin,
                          py_val, Py_None, AS_INDEX_TYPE_DEFAULT);
 
-error:
+exit:
     Py_INCREF(Py_None);
     return Py_None;
 }
@@ -72,6 +72,20 @@ static PyObject *AerospikePredicates_Contains(PyObject *self, PyObject *args)
     if (PyArg_ParseTuple(args, "OOO:equals", &py_bin, &py_indextype, &py_val) ==
         false) {
         return NULL;
+    }
+
+    as_index_datatype index_datatype;
+    if (PyLong_Check(py_val)) {
+        index_datatype = AS_INDEX_NUMERIC;
+    }
+    else if (PyUnicode_Check(py_val)) {
+        index_datatype = AS_INDEX_STRING;
+    }
+    else if (PyBytes_Check(py_val) || PyByteArray_Check(py_val)) {
+        index_datatype = AS_INDEX_BLOB;
+    }
+    else {
+        goto exit;
     }
 
     if (PyLong_Check(py_indextype)) {
@@ -90,9 +104,10 @@ static PyObject *AerospikePredicates_Contains(PyObject *self, PyObject *args)
                              py_bin, py_val, Py_None, index_type);
     }
     else if (PyBytes_Check(py_val) || PyByteArray_Check(py_val)) {
-        return Py_BuildValue("iiOOOi", AS_PREDICATE_EQUAL, AS_INDEX_BLOB,
-                             py_bin, py_val, Py_None, index_type);
     }
+
+    return Py_BuildValue("iiOOOi", AS_PREDICATE_EQUAL, AS_INDEX_BLOB, py_bin,
+                         py_val, Py_None, index_type);
 
 exit:
     Py_INCREF(Py_None);

--- a/src/main/query/where.c
+++ b/src/main/query/where.c
@@ -97,7 +97,7 @@ static int AerospikeQuery_Where_Add(AerospikeQuery *self, PyObject *py_ctx,
     Py_ssize_t bytes_size = 0;
 
     if (in_datatype == AS_INDEX_STRING || in_datatype == AS_INDEX_GEO2DSPHERE) {
-        if (PyUnicode_Check(py_val1)) {
+        if (!PyUnicode_Check(py_val1)) {
             goto CLEANUP;
         }
         val1_str = PyUnicode_AsUTF8(py_val1);

--- a/src/main/query/where.c
+++ b/src/main/query/where.c
@@ -67,16 +67,17 @@ static int AerospikeQuery_Where_Add(AerospikeQuery *self, PyObject *py_ctx,
         }
     }
 
+    const char *buffer = NULL;
     char *bin = NULL;
     if (PyUnicode_Check(py_bin)) {
-        bin = PyUnicode_AsUTF8(py_bin);
-        if (!bin) {
+        buffer = PyUnicode_AsUTF8(py_bin);
+        if (!buffer) {
             goto CLEANUP;
         }
     }
     else if (PyByteArray_Check(py_bin)) {
-        bin = PyByteArray_AsString(py_bin);
-        if (!bin) {
+        buffer = PyByteArray_AsString(py_bin);
+        if (!buffer) {
             goto CLEANUP;
         }
     }
@@ -84,7 +85,7 @@ static int AerospikeQuery_Where_Add(AerospikeQuery *self, PyObject *py_ctx,
         // Bins are required for all where() calls
         goto CLEANUP;
     }
-    bin = strdup(bin);
+    bin = strdup(buffer);
 
     int64_t val1_int = 0;
     int64_t val2_int = 0;

--- a/src/main/query/where.c
+++ b/src/main/query/where.c
@@ -67,17 +67,16 @@ static int AerospikeQuery_Where_Add(AerospikeQuery *self, PyObject *py_ctx,
         }
     }
 
-    const char *buffer = NULL;
-    char *bin = NULL;
+    const char *bin = NULL;
     if (PyUnicode_Check(py_bin)) {
-        buffer = PyUnicode_AsUTF8(py_bin);
-        if (!buffer) {
+        bin = PyUnicode_AsUTF8(py_bin);
+        if (!bin) {
             goto CLEANUP;
         }
     }
     else if (PyByteArray_Check(py_bin)) {
-        buffer = PyByteArray_AsString(py_bin);
-        if (!buffer) {
+        bin = PyByteArray_AsString(py_bin);
+        if (!bin) {
             goto CLEANUP;
         }
     }
@@ -85,7 +84,6 @@ static int AerospikeQuery_Where_Add(AerospikeQuery *self, PyObject *py_ctx,
         // Bins are required for all where() calls
         goto CLEANUP;
     }
-    bin = strdup(buffer);
 
     int64_t val1_int = 0;
     int64_t val2_int = 0;
@@ -195,10 +193,6 @@ static int AerospikeQuery_Where_Add(AerospikeQuery *self, PyObject *py_ctx,
     rc = 0;
 
 CLEANUP:
-
-    if (bin) {
-        free(bin);
-    }
 
     if (rc) {
         if (ctx_in_use) {

--- a/src/main/query/where.c
+++ b/src/main/query/where.c
@@ -93,6 +93,7 @@ static int AerospikeQuery_Where_Add(AerospikeQuery *self, PyObject *py_ctx,
     int64_t val1 = 0;
     int64_t val2 = 0;
     const char *val1_str = NULL;
+    uint8_t *val1_bytes = NULL;
     Py_ssize_t bytes_size = 0;
     if (in_datatype == AS_INDEX_STRING) {
         if (PyUnicode_Check(py_val1)) {
@@ -109,24 +110,22 @@ static int AerospikeQuery_Where_Add(AerospikeQuery *self, PyObject *py_ctx,
         }
     }
     else if (in_datatype == AS_INDEX_BLOB) {
-        uint8_t *val = NULL;
-        ;
-
         if (PyBytes_Check(py_val1)) {
-            val = (uint8_t *)PyBytes_AsString(py_val1);
+            val1_bytes = (uint8_t *)PyBytes_AsString(py_val1);
             bytes_size = PyBytes_Size(py_val1);
         }
         else if (PyByteArray_Check(py_val1)) {
-            val = (uint8_t *)PyByteArray_AsString(py_val1);
+            val1_bytes = (uint8_t *)PyByteArray_AsString(py_val1);
             bytes_size = PyByteArray_Size(py_val1);
         }
         else {
             rc = 1;
         }
 
-        uint8_t *bytes_buffer = (uint8_t *)malloc(sizeof(uint8_t) * bytes_size);
-        memcpy(bytes_buffer, val, sizeof(uint8_t) * bytes_size);
-        val = bytes_buffer;
+        uint8_t *val1_bytes_cpy =
+            (uint8_t *)malloc(sizeof(uint8_t) * bytes_size);
+        memcpy(val1_bytes_cpy, val1_bytes, sizeof(uint8_t) * bytes_size);
+        val1_bytes = val1_bytes_cpy;
     }
 
     as_query_where_init(&self->query, 1);

--- a/src/main/query/where.c
+++ b/src/main/query/where.c
@@ -176,9 +176,9 @@ static int AerospikeQuery_Where_Add(AerospikeQuery *self, PyObject *py_ctx,
         PyObject *py_err = NULL;
         error_to_pyobject(&err, &py_err);
         PyErr_SetObject(PyExc_Exception, py_err);
-        rc = 1;
     }
 
+    rc = 0;
 CLEANUP:
 
     if (rc) {

--- a/src/main/query/where.c
+++ b/src/main/query/where.c
@@ -256,23 +256,23 @@ AerospikeQuery *AerospikeQuery_Where_Invoke(AerospikeQuery *self,
         goto CLEANUP;
     }
 
-    PyObject *py_bin;
-    PyObject *py_val1;
-    PyObject *py_val2;
+    PyObject *py_bin = NULL;
+    PyObject *py_val1 = NULL;
+    PyObject *py_val2 = NULL;
     PyObject **py_optional_tuple_items[] = {&py_bin, &py_val1, &py_val2};
 
     // Read optional tuple items
     const unsigned long FIRST_OPTIONAL_IDX = 2;
     for (unsigned long i = FIRST_OPTIONAL_IDX; i <= 4; i++) {
         if (i <= size - 1) {
-            *(py_optional_tuple_items[i - FIRST_OPTIONAL_IDX]) =
-                PyTuple_GetItem(py_predicate, i);
-            if (!py_bin) {
+            PyObject *py_tuple_item = PyTuple_GetItem(py_predicate, i);
+            if (!py_tuple_item) {
                 goto CLEANUP;
             }
+            *(py_optional_tuple_items[i - FIRST_OPTIONAL_IDX]) = py_tuple_item;
         }
         else {
-            py_bin = Py_None;
+            *(py_optional_tuple_items[i - FIRST_OPTIONAL_IDX]) = Py_None;
         }
     }
 

--- a/src/main/query/where.c
+++ b/src/main/query/where.c
@@ -86,7 +86,7 @@ static int AerospikeQuery_Where_Add(AerospikeQuery *self, PyObject *py_ctx,
 
     int64_t val1_int = 0;
     int64_t val2_int = 0;
-    const char *val1_str = NULL;
+    char *val1_str = NULL;
     uint8_t *val1_bytes = NULL;
 
     // Can point to either val1_int or val1_str. We use this so we can pass in the same optional argument
@@ -99,11 +99,11 @@ static int AerospikeQuery_Where_Add(AerospikeQuery *self, PyObject *py_ctx,
         if (!PyUnicode_Check(py_val1)) {
             goto CLEANUP1;
         }
-        val1_str = PyUnicode_AsUTF8(py_val1);
-        if (!val1_str) {
+        const char *buffer = PyUnicode_AsUTF8(py_val1);
+        if (!buffer) {
             goto CLEANUP1;
         }
-        val1_str = strdup(val1_str);
+        val1_str = strdup(buffer);
         val1 = (void *)val1_str;
     }
     else if (in_datatype == AS_INDEX_NUMERIC) {

--- a/src/main/query/where.c
+++ b/src/main/query/where.c
@@ -190,6 +190,9 @@ static int AerospikeQuery_Where_Add(AerospikeQuery *self, PyObject *py_ctx,
         goto CLEANUP2;
     }
 
+    if (ctx_in_use) {
+        self->query.where.entries[0].ctx_free = true;
+    }
     rc = 0;
 
 CLEANUP2:
@@ -214,9 +217,6 @@ CLEANUP1:
         if (pctx) {
             cf_free(pctx);
         }
-    }
-    else if (ctx_in_use) {
-        self->query.where.entries[0].ctx_free = true;
     }
 
     return rc;

--- a/src/main/query/where.c
+++ b/src/main/query/where.c
@@ -142,8 +142,6 @@ static int AerospikeQuery_Where_Add(AerospikeQuery *self, PyObject *py_ctx,
                                     index_type, in_datatype, val1_str,
                                     bytes_size, true);
         }
-        // Cleanup
-        free(bin);
     }
     else if (in_datatype == AS_INDEX_BLOB ||
              in_datatype == AS_INDEX_GEO2DSPHERE ||

--- a/src/main/query/where.c
+++ b/src/main/query/where.c
@@ -74,7 +74,7 @@ static int AerospikeQuery_Where_Add(AerospikeQuery *self, PyObject *py_ctx,
         }
     }
 
-    char *bin = NULL;
+    const char *bin = NULL;
     if (py_bin) {
         if (PyUnicode_Check(py_bin)) {
             bin = PyUnicode_AsUTF8(py_bin);
@@ -92,7 +92,7 @@ static int AerospikeQuery_Where_Add(AerospikeQuery *self, PyObject *py_ctx,
 
     int64_t val1 = 0;
     int64_t val2 = 0;
-    char *val1_str = NULL;
+    const char *val1_str = NULL;
     Py_ssize_t bytes_size = 0;
     if (in_datatype == AS_INDEX_STRING) {
         if (PyUnicode_Check(py_val1)) {

--- a/src/main/query/where.c
+++ b/src/main/query/where.c
@@ -109,7 +109,7 @@ static int AerospikeQuery_Where_Add(AerospikeQuery *self, PyObject *py_ctx,
         val1_int = pyobject_to_int64(py_val1);
         if (PyErr_Occurred()) {
             PyErr_Clear();
-            val1 = 0;
+            val1_int = 0;
         }
         val1 = (void *)val1_int;
 

--- a/src/main/query/where.c
+++ b/src/main/query/where.c
@@ -43,7 +43,6 @@ int64_t pyobject_to_int64(PyObject *py_obj)
 }
 
 // py_bin, py_val1, pyval2 are guaranteed to be non-NULL
-// py_bin is guaranteed
 static int AerospikeQuery_Where_Add(AerospikeQuery *self, PyObject *py_ctx,
                                     as_predicate_type predicate,
                                     as_index_datatype in_datatype,

--- a/src/main/query/where.c
+++ b/src/main/query/where.c
@@ -271,8 +271,8 @@ AerospikeQuery *AerospikeQuery_Where_Invoke(AerospikeQuery *self,
     PyObject **py_optional_tuple_items[] = {&py_bin, &py_val1, &py_val2};
 
     // Read optional tuple items
-    const unsigned long FIRST_OPTIONAL_IDX = 2;
-    for (unsigned long i = FIRST_OPTIONAL_IDX; i <= 4; i++) {
+    const Py_ssize_t FIRST_OPTIONAL_IDX = 2;
+    for (Py_ssize_t i = FIRST_OPTIONAL_IDX; i <= 4; i++) {
         PyObject *py_tuple_item;
         if (i <= size - 1) {
             py_tuple_item = PyTuple_GetItem(py_predicate, i);

--- a/src/main/query/where.c
+++ b/src/main/query/where.c
@@ -211,23 +211,25 @@ AerospikeQuery *AerospikeQuery_Where_Invoke(AerospikeQuery *self,
 
         Py_ssize_t size = PyTuple_Size(py_arg2);
 
-        PyObject *py_op = PyTuple_GetItem(py_arg2, 0);
-        PyObject *py_op_data = PyTuple_GetItem(py_arg2, 1);
-        if (!py_op || !py_op_data) {
+        PyObject *py_predicate_type = PyTuple_GetItem(py_predicate, 0);
+        PyObject *py_index_datatype = PyTuple_GetItem(py_predicate, 1);
+        if (!py_predicate_type || !py_index_datatype) {
             as_error_update(&err, AEROSPIKE_ERR_CLIENT,
                             "Failed to fetch predicate information");
             goto CLEANUP;
         }
-        if (PyLong_Check(py_op) && PyLong_Check(py_op_data)) {
-            as_predicate_type op = (as_predicate_type)PyLong_AsLong(py_op);
-            as_index_datatype op_data =
-                (as_index_datatype)PyLong_AsLong(py_op_data);
+        if (PyLong_Check(py_predicate_type) &&
+            PyLong_Check(py_index_datatype)) {
+            as_predicate_type predicate_type =
+                (as_predicate_type)PyLong_AsLong(py_predicate_type);
+            as_index_datatype index_datatype =
+                (as_index_datatype)PyLong_AsLong(py_index_datatype);
             rc = AerospikeQuery_Where_Add(
-                self, py_arg1, op, op_data,
-                size > 2 ? PyTuple_GetItem(py_arg2, 2) : Py_None,
-                size > 3 ? PyTuple_GetItem(py_arg2, 3) : Py_None,
-                size > 4 ? PyTuple_GetItem(py_arg2, 4) : Py_None,
-                size > 5 ? PyLong_AsLong(PyTuple_GetItem(py_arg2, 5)) : 0);
+                self, py_ctx, py_exp, predicate_type, index_datatype,
+                size > 2 ? PyTuple_GetItem(py_predicate, 2) : Py_None,
+                size > 3 ? PyTuple_GetItem(py_predicate, 3) : Py_None,
+                size > 4 ? PyTuple_GetItem(py_predicate, 4) : Py_None,
+                size > 5 ? PyLong_AsLong(PyTuple_GetItem(py_predicate, 5)) : 0);
             /* Failed to add the predicate for some reason */
             if (rc != 0) {
                 as_error_update(&err, AEROSPIKE_ERR_PARAM,

--- a/src/main/query/where.c
+++ b/src/main/query/where.c
@@ -236,8 +236,8 @@ AerospikeQuery *AerospikeQuery_Where_Invoke(AerospikeQuery *self,
                         PREDICATE_INVALID_ERROR_MSG1);
         goto CLEANUP;
     }
-    Py_ssize_t size = PyTuple_Size(py_predicate);
-    if (size <= 1 || size > 6) {
+    Py_ssize_t predicate_size = PyTuple_Size(py_predicate);
+    if (predicate_size <= 1 || predicate_size > 6) {
         as_error_update(&err, AEROSPIKE_ERR_PARAM,
                         PREDICATE_INVALID_ERROR_MSG1);
         goto CLEANUP;
@@ -283,7 +283,7 @@ AerospikeQuery *AerospikeQuery_Where_Invoke(AerospikeQuery *self,
     const Py_ssize_t FIRST_OPTIONAL_IDX = 2;
     for (Py_ssize_t i = FIRST_OPTIONAL_IDX; i <= 4; i++) {
         PyObject *py_tuple_item;
-        if (i <= size - 1) {
+        if (i <= predicate_size - 1) {
             py_tuple_item = PyTuple_GetItem(py_predicate, i);
             if (!py_tuple_item) {
                 goto CLEANUP;
@@ -296,7 +296,7 @@ AerospikeQuery *AerospikeQuery_Where_Invoke(AerospikeQuery *self,
     }
 
     as_index_type index_type;
-    if (size == 6) {
+    if (predicate_size == 6) {
         PyObject *py_index_type = PyTuple_GetItem(py_predicate, 5);
         if (!py_index_type) {
             goto CLEANUP;

--- a/src/main/query/where.c
+++ b/src/main/query/where.c
@@ -67,7 +67,7 @@ static int AerospikeQuery_Where_Add(AerospikeQuery *self, PyObject *py_ctx,
         }
     }
 
-    const char *bin = NULL;
+    char *bin = NULL;
     if (PyUnicode_Check(py_bin)) {
         bin = PyUnicode_AsUTF8(py_bin);
         if (!bin) {
@@ -84,7 +84,7 @@ static int AerospikeQuery_Where_Add(AerospikeQuery *self, PyObject *py_ctx,
         // Bins are required for all where() calls
         goto CLEANUP;
     }
-    bin = (const char *)strdup(bin);
+    bin = strdup(bin);
 
     int64_t val1_int = 0;
     int64_t val2_int = 0;

--- a/src/main/query/where.c
+++ b/src/main/query/where.c
@@ -135,7 +135,7 @@ static int AerospikeQuery_Where_Add(AerospikeQuery *self, PyObject *py_ctx,
         }
         else if (PyByteArray_Check(py_val1)) {
             bytes_buffer = PyByteArray_AsString(py_val1);
-            if (!val1_bytes) {
+            if (!bytes_buffer) {
                 goto CLEANUP_ON_ERROR1;
             }
             bytes_size = PyByteArray_Size(py_val1);

--- a/src/main/query/where.c
+++ b/src/main/query/where.c
@@ -195,6 +195,10 @@ static int AerospikeQuery_Where_Add(AerospikeQuery *self, PyObject *py_ctx,
 CLEANUP:
 
     if (rc) {
+        // The values end up not being used by as_query
+        if (val1_str) {
+            free(val1_str);
+        }
         if (val1_bytes) {
             free(val1_bytes);
         }

--- a/test/new_tests/test_query.py
+++ b/test/new_tests/test_query.py
@@ -1051,6 +1051,16 @@ class TestQuery(TestBaseClass):
         assert records
         assert len(records) == 3
 
+    def test_query_with_list_cdt_ctx_and_invalid_bin(self):
+        """
+        Make sure that ctx is being cleaned up properly
+        """
+        query = self.as_connection.query("test", "demo")
+        query.select("numeric_list")
+        # Invalid bin
+        with pytest.raises(e.ParamError):
+            query.where(p.range(5, aerospike.INDEX_TYPE_DEFAULT, 2, 4), {"ctx": ctx_list_index})
+
     def test_query_with_map_cdt_ctx(self):
         """
         Invoke query() with cdt_ctx and correct arguments

--- a/test/new_tests/test_query.py
+++ b/test/new_tests/test_query.py
@@ -1056,10 +1056,15 @@ class TestQuery(TestBaseClass):
         Make sure that ctx is being cleaned up properly
         """
         query = self.as_connection.query("test", "demo")
-        query.select("numeric_list")
         # Invalid bin
         with pytest.raises(e.ParamError):
             query.where(p.range(5, aerospike.INDEX_TYPE_DEFAULT, 2, 4), {"ctx": ctx_list_index})
+
+    def test_query_with_invalid_predicate_type(self):
+        query = self.as_connection.query("test", "demo")
+        with pytest.raises(e.ParamError):
+            # 2 is outside valid values for predicate types
+            query.where((2, aerospike.INDEX_BLOB, "bin", bytearray(b'123')))
 
     def test_query_with_map_cdt_ctx(self):
         """


### PR DESCRIPTION
All tests passing except for one because of a broken link in docs (unrelated)

Extra changes:
Add test coverage for cleaning up `ctx` if query.where() fails and for passing an invalid predicate type

Prep work for sindex expression changes

Notes:
- There's a TODO about how static pool is used in where.c, but Dominic is currently working on a PR to replace it with dynamic pool, so I think we can leave that as-is for now. This PR shouldn't change the behavior of the static pool

No breaking changes in predicates.c, since predicates are also used in client.query_apply()

---
Build artifacts passes
Valgrind shows no memory errors or leaks from these changes
Massif usage looks ok
Verified with Brian Nichols that the refactoring looks ok