### PR TITLE
[CLIENT-3620] Prevent users from creating Query and Scan objects using their class constructors

### DIFF
--- a/src/main/query/type.c
+++ b/src/main/query/type.c
@@ -291,7 +291,7 @@ static PyTypeObject AerospikeQuery_Type = {
     0,                                  // tp_dictoffset
     (initproc)AerospikeQuery_Type_Init, // tp_init
     0,                                  // tp_alloc
-    AerospikeQuery_Type_New,            // tp_new
+    NULL,                               // tp_new
     0,                                  // tp_free
     0,                                  // tp_is_gc
     0                                   // tp_bases


### PR DESCRIPTION
This causes a seg fault