### PR TITLE
[CLIENT-3620] Log a warning when aerospike.{Query,Scan} class constructors are used to create query/scan instances

### DIFF
--- a/doc/client.rst
+++ b/doc/client.rst
@@ -1296,7 +1296,7 @@ The user dictionary has the following key-value pairs:
     * ``"roles"`` (:class:`list[str]`): list of assigned role names.
 
 Scan and Query Constructors
-===========================
+---------------------------
 
 .. class:: Client
     :noindex:

--- a/doc/client.rst
+++ b/doc/client.rst
@@ -1296,7 +1296,7 @@ The user dictionary has the following key-value pairs:
     * ``"roles"`` (:class:`list[str]`): list of assigned role names.
 
 Scan and Query Constructors
----------------------------
+===========================
 
 .. class:: Client
     :noindex:

--- a/src/include/query.h
+++ b/src/include/query.h
@@ -148,5 +148,5 @@ PyObject *StoreUnicodePyObject(AerospikeQuery *self, PyObject *obj);
 
 int64_t pyobject_to_int64(PyObject *py_obj);
 
-PyObject *AerospikeScan_Type_New(PyTypeObject *type, PyObject *args,
-                                 PyObject *kwds);
+PyObject *AerospikeQuery_Type_New(PyTypeObject *type, PyObject *args,
+                                  PyObject *kwds);

--- a/src/include/query.h
+++ b/src/include/query.h
@@ -30,9 +30,6 @@
 
 PyTypeObject *AerospikeQuery_Ready(void);
 
-AerospikeQuery *AerospikeQuery_New(AerospikeClient *client, PyObject *args,
-                                   PyObject *kwds);
-
 /*******************************************************************************
  * OPERATIONS
  ******************************************************************************/

--- a/src/include/query.h
+++ b/src/include/query.h
@@ -147,3 +147,6 @@ PyObject *AerospikeQuery_Get_Partitions_status(AerospikeQuery *self);
 PyObject *StoreUnicodePyObject(AerospikeQuery *self, PyObject *obj);
 
 int64_t pyobject_to_int64(PyObject *py_obj);
+
+PyObject *AerospikeScan_Type_New(PyTypeObject *type, PyObject *args,
+                                 PyObject *kwds);

--- a/src/include/scan.h
+++ b/src/include/scan.h
@@ -130,5 +130,5 @@ PyObject *AerospikeScan_Is_Done(AerospikeScan *self, PyObject *args,
  */
 PyObject *AerospikeScan_Get_Partitions_status(AerospikeScan *self);
 
-AerospikeScan *AerospikeScan_Type_New(AerospikeClient *client, PyObject *args,
-                                      PyObject *kwds);
+PyObject *AerospikeScan_Type_New(PyTypeObject *type, PyObject *args,
+                                 PyObject *kwds);

--- a/src/include/scan.h
+++ b/src/include/scan.h
@@ -129,3 +129,6 @@ PyObject *AerospikeScan_Is_Done(AerospikeScan *self, PyObject *args,
  *
  */
 PyObject *AerospikeScan_Get_Partitions_status(AerospikeScan *self);
+
+AerospikeScan *AerospikeScan_New(AerospikeClient *client, PyObject *args,
+                                 PyObject *kwds);

--- a/src/include/scan.h
+++ b/src/include/scan.h
@@ -30,9 +30,6 @@
 
 PyTypeObject *AerospikeScan_Ready(void);
 
-AerospikeScan *AerospikeScan_New(AerospikeClient *client, PyObject *args,
-                                 PyObject *kwds);
-
 /*******************************************************************************
  * OPERATIONS
  ******************************************************************************/

--- a/src/include/scan.h
+++ b/src/include/scan.h
@@ -130,5 +130,5 @@ PyObject *AerospikeScan_Is_Done(AerospikeScan *self, PyObject *args,
  */
 PyObject *AerospikeScan_Get_Partitions_status(AerospikeScan *self);
 
-AerospikeScan *AerospikeScan_New(AerospikeClient *client, PyObject *args,
-                                 PyObject *kwds);
+AerospikeScan *AerospikeScan_Type_New(AerospikeClient *client, PyObject *args,
+                                      PyObject *kwds);

--- a/src/main/client/query.c
+++ b/src/main/client/query.c
@@ -42,11 +42,25 @@
  * In case of error,appropriate exceptions will be raised.
  *******************************************************************************************************
  */
+
+extern PyTypeObject AerospikeQuery_Type;
+
 AerospikeQuery *AerospikeClient_Query(AerospikeClient *self, PyObject *args,
                                       PyObject *kwds)
 {
-    return AerospikeQuery_New(self, args, kwds);
+    AerospikeQuery *query = (AerospikeQuery *)AerospikeQuery_Type_New(
+        &AerospikeQuery_Type, args, kwds);
+    query->client = self;
+
+    if (AerospikeQuery_Type.tp_init((PyObject *)query, args, kwds) == 0) {
+        Py_INCREF(self);
+        return query;
+    }
+
+    AerospikeQuery_Type.tp_free(query);
+    return NULL;
 }
+
 static int query_where_add(as_query **query, as_predicate_type predicate,
                            as_index_datatype in_datatype, PyObject *py_bin,
                            PyObject *py_val1, PyObject *py_val2, int index_type,

--- a/src/main/client/scan.c
+++ b/src/main/client/scan.c
@@ -43,10 +43,27 @@
  * In case of error,appropriate exceptions will be raised.
  *******************************************************************************************************
  */
+
+extern PyTypeObject AerospikeScan_Type;
+
 AerospikeScan *AerospikeClient_Scan(AerospikeClient *self, PyObject *args,
                                     PyObject *kwds)
 {
-    return AerospikeScan_New(self, args, kwds);
+    AerospikeScan *scan = (AerospikeScan *)AerospikeScan_Type_New(
+        &AerospikeScan_Type, args, kwds);
+    scan->client = self;
+    Py_INCREF(self);
+    if (AerospikeScan_Type.tp_init((PyObject *)scan, args, kwds) != -1) {
+        return scan;
+    }
+    else {
+        Py_XDECREF(scan);
+        as_error err;
+        as_error_init(&err);
+        as_error_update(&err, AEROSPIKE_ERR_PARAM, "Parameters are incorrect");
+        raise_exception(&err);
+        return NULL;
+    }
 }
 
 /**

--- a/src/main/query/type.c
+++ b/src/main/query/type.c
@@ -156,8 +156,8 @@ static PyMemberDef AerospikeQuery_Type_custom_members[] = {
  * PYTHON TYPE HOOKS
  ******************************************************************************/
 
-static PyObject *AerospikeQuery_Type_New(PyTypeObject *type, PyObject *args,
-                                         PyObject *kwds)
+PyObject *AerospikeQuery_Type_New(PyTypeObject *type, PyObject *args,
+                                  PyObject *kwds)
 {
     AerospikeQuery *self = NULL;
 

--- a/src/main/query/type.c
+++ b/src/main/query/type.c
@@ -258,7 +258,7 @@ static void AerospikeQuery_Type_Dealloc(AerospikeQuery *self)
 /*******************************************************************************
  * PYTHON TYPE DESCRIPTOR
  ******************************************************************************/
-static PyTypeObject AerospikeQuery_Type = {
+PyTypeObject AerospikeQuery_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
         FULLY_QUALIFIED_TYPE_NAME("Query"), // tp_name
     sizeof(AerospikeQuery),                 // tp_basicsize

--- a/src/main/query/type.c
+++ b/src/main/query/type.c
@@ -23,6 +23,7 @@
 #include <aerospike/as_error.h>
 #include <aerospike/as_policy.h>
 #include <aerospike/as_query.h>
+#include <aerospike/as_log_macros.h>
 
 #include "client.h"
 #include "query.h"
@@ -155,6 +156,15 @@ static PyMemberDef AerospikeQuery_Type_custom_members[] = {
  * PYTHON TYPE HOOKS
  ******************************************************************************/
 
+static PyObject *AerospikeQuery_Type_New_With_Warning(PyTypeObject *type,
+                                                      PyObject *args,
+                                                      PyObject *kwds)
+{
+    as_log_warn("aerospike.Query() should not be called directly to create a "
+                "Query instance. Use aerospike.Client.query() instead");
+    return AerospikeQuery_Type_New(type, args, kwds);
+}
+
 static PyObject *AerospikeQuery_Type_New(PyTypeObject *type, PyObject *args,
                                          PyObject *kwds)
 {
@@ -275,26 +285,26 @@ static PyTypeObject AerospikeQuery_Type = {
     "operation. To create a new instance of the Query class, call the\n"
     "query() method on an instance of a Client class.\n",
     // tp_doc
-    0,                                  // tp_traverse
-    0,                                  // tp_clear
-    0,                                  // tp_richcompare
-    0,                                  // tp_weaklistoffset
-    0,                                  // tp_iter
-    0,                                  // tp_iternext
-    AerospikeQuery_Type_Methods,        // tp_methods
-    AerospikeQuery_Type_custom_members, // tp_members
-    0,                                  // tp_getset
-    0,                                  // tp_base
-    0,                                  // tp_dict
-    0,                                  // tp_descr_get
-    0,                                  // tp_descr_set
-    0,                                  // tp_dictoffset
-    (initproc)AerospikeQuery_Type_Init, // tp_init
-    0,                                  // tp_alloc
-    AerospikeQuery_Type_New,            // tp_new
-    0,                                  // tp_free
-    0,                                  // tp_is_gc
-    0                                   // tp_bases
+    0,                                    // tp_traverse
+    0,                                    // tp_clear
+    0,                                    // tp_richcompare
+    0,                                    // tp_weaklistoffset
+    0,                                    // tp_iter
+    0,                                    // tp_iternext
+    AerospikeQuery_Type_Methods,          // tp_methods
+    AerospikeQuery_Type_custom_members,   // tp_members
+    0,                                    // tp_getset
+    0,                                    // tp_base
+    0,                                    // tp_dict
+    0,                                    // tp_descr_get
+    0,                                    // tp_descr_set
+    0,                                    // tp_dictoffset
+    (initproc)AerospikeQuery_Type_Init,   // tp_init
+    0,                                    // tp_alloc
+    AerospikeQuery_Type_New_With_Warning, // tp_new
+    0,                                    // tp_free
+    0,                                    // tp_is_gc
+    0                                     // tp_bases
 };
 
 /*******************************************************************************
@@ -310,7 +320,7 @@ PyTypeObject *AerospikeQuery_Ready()
 AerospikeQuery *AerospikeQuery_New(AerospikeClient *client, PyObject *args,
                                    PyObject *kwds)
 {
-    AerospikeQuery *self = (AerospikeQuery *)AerospikeQuery_Type.tp_new(
+    AerospikeQuery *self = (AerospikeQuery *)AerospikeQuery_Type_New(
         &AerospikeQuery_Type, args, kwds);
     self->client = client;
 

--- a/src/main/query/type.c
+++ b/src/main/query/type.c
@@ -317,22 +317,6 @@ PyTypeObject *AerospikeQuery_Ready()
                                                    : NULL;
 }
 
-AerospikeQuery *AerospikeQuery_New(AerospikeClient *client, PyObject *args,
-                                   PyObject *kwds)
-{
-    AerospikeQuery *self = (AerospikeQuery *)AerospikeQuery_Type_New(
-        &AerospikeQuery_Type, args, kwds);
-    self->client = client;
-
-    if (AerospikeQuery_Type.tp_init((PyObject *)self, args, kwds) == 0) {
-        Py_INCREF(client);
-        return self;
-    }
-
-    AerospikeQuery_Type.tp_free(self);
-    return NULL;
-}
-
 PyObject *StoreUnicodePyObject(AerospikeQuery *self, PyObject *obj)
 {
     if (self->u_objs.size < MAX_UNICODE_OBJECTS) {

--- a/src/main/query/type.c
+++ b/src/main/query/type.c
@@ -156,15 +156,6 @@ static PyMemberDef AerospikeQuery_Type_custom_members[] = {
  * PYTHON TYPE HOOKS
  ******************************************************************************/
 
-static PyObject *AerospikeQuery_Type_New_With_Warning(PyTypeObject *type,
-                                                      PyObject *args,
-                                                      PyObject *kwds)
-{
-    as_log_warn("aerospike.Query() should not be called directly to create a "
-                "Query instance. Use aerospike.Client.query() instead");
-    return AerospikeQuery_Type_New(type, args, kwds);
-}
-
 static PyObject *AerospikeQuery_Type_New(PyTypeObject *type, PyObject *args,
                                          PyObject *kwds)
 {
@@ -177,6 +168,15 @@ static PyObject *AerospikeQuery_Type_New(PyTypeObject *type, PyObject *args,
     }
 
     return (PyObject *)self;
+}
+
+static PyObject *AerospikeQuery_Type_New_With_Warning(PyTypeObject *type,
+                                                      PyObject *args,
+                                                      PyObject *kwds)
+{
+    as_log_warn("aerospike.Query() should not be called directly to create a "
+                "Query instance. Use aerospike.Client.query() instead");
+    return AerospikeQuery_Type_New(type, args, kwds);
 }
 
 static int AerospikeQuery_Type_Init(AerospikeQuery *self, PyObject *args,

--- a/src/main/scan/type.c
+++ b/src/main/scan/type.c
@@ -183,6 +183,15 @@ static void AerospikeScan_Type_Dealloc(AerospikeScan *self)
     Py_TYPE(self)->tp_free((PyObject *)self);
 }
 
+static PyObject *AerospikeScan_Type_New_With_Warning(PyTypeObject *type,
+                                                     PyObject *args,
+                                                     PyObject *kwds)
+{
+    as_log_warn("aerospike.Scan() should not be called directly to create a "
+                "Scan instance. Use aerospike.Client.Scan() instead");
+    return AerospikeScan_Type_New(type, args, kwds);
+}
+
 /*******************************************************************************
  * PYTHON TYPE DESCRIPTOR
  ******************************************************************************/
@@ -229,11 +238,11 @@ static PyTypeObject AerospikeScan_Type = {
     0,                                 // tp_dictoffset
     (initproc)AerospikeScan_Type_Init,
     // tp_init
-    0,                      // tp_alloc
-    AerospikeScan_Type_New, // tp_new
-    0,                      // tp_free
-    0,                      // tp_is_gc
-    0                       // tp_bases
+    0,                                   // tp_alloc
+    AerospikeScan_Type_New_With_Warning, // tp_new
+    0,                                   // tp_free
+    0,                                   // tp_is_gc
+    0                                    // tp_bases
 };
 
 /*******************************************************************************
@@ -248,7 +257,7 @@ PyTypeObject *AerospikeScan_Ready()
 AerospikeScan *AerospikeScan_New(AerospikeClient *client, PyObject *args,
                                  PyObject *kwds)
 {
-    AerospikeScan *self = (AerospikeScan *)AerospikeScan_Type.tp_new(
+    AerospikeScan *self = (AerospikeScan *)AerospikeScan_Type_New(
         &AerospikeScan_Type, args, kwds);
     self->client = client;
     Py_INCREF(client);

--- a/src/main/scan/type.c
+++ b/src/main/scan/type.c
@@ -23,6 +23,7 @@
 #include <aerospike/as_error.h>
 #include <aerospike/as_policy.h>
 #include <aerospike/as_scan.h>
+#include <aerospike/as_log_macros.h>
 
 #include "client.h"
 #include "scan.h"

--- a/src/main/scan/type.c
+++ b/src/main/scan/type.c
@@ -197,7 +197,7 @@ static PyObject *AerospikeScan_Type_New_With_Warning(PyTypeObject *type,
  * PYTHON TYPE DESCRIPTOR
  ******************************************************************************/
 
-static PyTypeObject AerospikeScan_Type = {
+PyTypeObject AerospikeScan_Type = {
     PyVarObject_HEAD_INIT(NULL, 0) FULLY_QUALIFIED_TYPE_NAME("Scan"), // tp_name
     sizeof(AerospikeScan), // tp_basicsize
     0,                     // tp_itemsize

--- a/src/main/scan/type.c
+++ b/src/main/scan/type.c
@@ -110,8 +110,8 @@ static PyMemberDef AerospikeScan_Type_custom_members[] = {
  * PYTHON TYPE HOOKS
  ******************************************************************************/
 
-static PyObject *AerospikeScan_Type_New(PyTypeObject *type, PyObject *args,
-                                        PyObject *kwds)
+PyObject *AerospikeScan_Type_New(PyTypeObject *type, PyObject *args,
+                                 PyObject *kwds)
 {
     AerospikeScan *self = NULL;
 

--- a/src/main/scan/type.c
+++ b/src/main/scan/type.c
@@ -254,23 +254,3 @@ PyTypeObject *AerospikeScan_Ready()
 {
     return PyType_Ready(&AerospikeScan_Type) == 0 ? &AerospikeScan_Type : NULL;
 }
-
-AerospikeScan *AerospikeScan_New(AerospikeClient *client, PyObject *args,
-                                 PyObject *kwds)
-{
-    AerospikeScan *self = (AerospikeScan *)AerospikeScan_Type_New(
-        &AerospikeScan_Type, args, kwds);
-    self->client = client;
-    Py_INCREF(client);
-    if (AerospikeScan_Type.tp_init((PyObject *)self, args, kwds) != -1) {
-        return self;
-    }
-    else {
-        Py_XDECREF(self);
-        as_error err;
-        as_error_init(&err);
-        as_error_update(&err, AEROSPIKE_ERR_PARAM, "Parameters are incorrect");
-        raise_exception(&err);
-        return NULL;
-    }
-}

--- a/test/new_tests/conftest.py
+++ b/test/new_tests/conftest.py
@@ -241,4 +241,5 @@ def invalid_key(request):
 def set_log_level(request):
     aerospike.set_log_level(aerospike.LOG_LEVEL_WARN)
     yield
+    # This is supposed to be the default across all the tests
     aerospike.set_log_level(aerospike.LOG_LEVEL_ERROR)

--- a/test/new_tests/conftest.py
+++ b/test/new_tests/conftest.py
@@ -236,3 +236,9 @@ def invalid_key(request):
 
 # aerospike.set_log_level(aerospike.LOG_LEVEL_DEBUG)
 # aerospike.set_log_handler(None)
+
+@pytest.fixture
+def set_log_level(request):
+    aerospike.set_log_level(aerospike.LOG_LEVEL_WARN)
+    yield
+    aerospike.set_log_level(aerospike.LOG_LEVEL_ERROR)

--- a/test/new_tests/test_query.py
+++ b/test/new_tests/test_query.py
@@ -1313,3 +1313,7 @@ class TestQuery(TestBaseClass):
 
         recs = query.results()
         assert len(recs) == expected_rec_count
+
+    # Usage test. We need to check the logs that a warning is printed
+    def test_class_constructor(self):
+        aerospike.Query("test", "demo")

--- a/test/new_tests/test_query.py
+++ b/test/new_tests/test_query.py
@@ -1315,5 +1315,5 @@ class TestQuery(TestBaseClass):
         assert len(recs) == expected_rec_count
 
     # Usage test. We need to check the logs that a warning is printed
-    def test_class_constructor(self):
+    def test_class_constructor(self, set_log_level):
         aerospike.Query("test", "demo")

--- a/test/new_tests/test_scan.py
+++ b/test/new_tests/test_scan.py
@@ -469,5 +469,5 @@ class TestScan(TestBaseClass):
             scan_obj.foreach(callback, {"expressions": expr.compile()})
 
     # Usage test. We need to check the logs that a warning is printed
-    def test_class_constructor(self):
+    def test_class_constructor(self, set_log_level):
         aerospike.Scan("test", "demo")

--- a/test/new_tests/test_scan.py
+++ b/test/new_tests/test_scan.py
@@ -467,3 +467,7 @@ class TestScan(TestBaseClass):
 
         with pytest.raises(e.InvalidRequest):
             scan_obj.foreach(callback, {"expressions": expr.compile()})
+
+    # Usage test. We need to check the logs that a warning is printed
+    def test_class_constructor(self):
+        aerospike.Scan("test", "demo")


### PR DESCRIPTION
`aerospike.Client.{scan,query}()` doesn't refer to Query or Scan's `tp_new`, which now points to a callback that prints a warning, so this warning will only be called if someone tries to call the constructors in their own code

Manual testing

Logs show up here: https://github.com/aerospike/aerospike-client-python/actions/runs/16632637715/job/47065876317?pr=809#step:12:3591