### PR TITLE
[CLIENT-3703] Fix bug where the default metrics writer does not specify the correct client language and version in the logs

### DIFF
--- a/test/new_tests/test_metrics.py
+++ b/test/new_tests/test_metrics.py
@@ -6,7 +6,8 @@ import glob
 import os
 import time
 from typing import Optional
-
+import re
+from importlib.metadata import version
 
 # Flags for testing callbacks
 enable_triggered = False
@@ -140,6 +141,18 @@ class TestMetrics:
         # A metrics log file should've been created
         metrics_log_filenames = glob.glob("./metrics-*.log")
         assert len(metrics_log_filenames) > 0
+
+        # The client language and version should be correct
+        try:
+            with open(metrics_log_filenames[0]) as f:
+                data = f.readline()
+            regex = re.search(pattern=r"cluster\[[a-zA-Z0-9_-$,]+,([a-z]+),([0-9.a-zA-Z+]+),", string=data)
+            client_language, client_version = regex.groups()
+            assert client_language == "python"
+            assert client_version == version("aerospike")
+        finally:
+            for item in metrics_log_filenames:
+                os.remove(item)
 
     def test_setting_metrics_policy_custom_settings(self):
         self.metrics_log_folder = "./metrics-logs"


### PR DESCRIPTION
…ent language and version. Add regression tests