### PR TITLE
[CLIENT-2159] Fix reference count leaks when a user passes in a MetricsPolicy to client.enable_metrics()

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -288,8 +288,9 @@ jobs:
         echo LIBRARY_PATH=$LIBRARY_PATH >> $GITHUB_ENV
       shell: bash
 
-    - if: ${{ inputs.platform-tag == 'macosx_x86_64' && matrix.python-tag == 'cp313' }}
+    - if: ${{ inputs.platform-tag == 'macosx_x86_64' }}
       # This fixes an issue where there is not enough room in the wheel's shared library to replace the rpath
+      # Just do it for all Python versions (even those that don't require more room) for futureproofing
       run: echo CIBW_ENVIRONMENT_MACOS="LDFLAGS='-headerpad_max_install_names'" >> $GITHUB_ENV
 
     - name: Build wheel

--- a/src/main/policy.c
+++ b/src/main/policy.c
@@ -1251,6 +1251,7 @@ int set_as_metrics_policy_using_pyobject(as_error *err,
         goto error;
     }
     strcpy(metrics_policy->report_dir, report_dir);
+    Py_DECREF(py_report_dir);
 
     const char *report_size_limit_attr_name = "report_size_limit";
     PyObject *py_report_size_limit =
@@ -1263,6 +1264,7 @@ int set_as_metrics_policy_using_pyobject(as_error *err,
 
     uint64_t report_size_limit =
         convert_pyobject_to_uint64_t(py_report_size_limit);
+    Py_DECREF(py_report_size_limit);
     if (PyErr_Occurred()) {
         as_error_update(err, AEROSPIKE_ERR_PARAM, INVALID_ATTR_TYPE_ERROR_MSG,
                         report_size_limit_attr_name, "unsigned 64-bit integer");
@@ -1280,6 +1282,7 @@ int set_as_metrics_policy_using_pyobject(as_error *err,
     }
 
     uint32_t interval = convert_pyobject_to_uint32_t(py_interval);
+    Py_DECREF(py_interval);
     if (PyErr_Occurred()) {
         as_error_update(err, AEROSPIKE_ERR_PARAM, INVALID_ATTR_TYPE_ERROR_MSG,
                         interval_field_name, "unsigned 32-bit integer");
@@ -1301,6 +1304,7 @@ int set_as_metrics_policy_using_pyobject(as_error *err,
         }
 
         uint8_t attr_value = convert_pyobject_to_uint8_t(py_attr_value);
+        Py_DECREF(py_attr_value);
         if (PyErr_Occurred()) {
             as_error_update(err, AEROSPIKE_ERR_PARAM,
                             INVALID_ATTR_TYPE_ERROR_MSG, uint8_field_names[i],


### PR DESCRIPTION
* With these changes, more macos x86 wheels need to have more space to replace the RPATH. So I just added more space for all Python versions to be safe

Extra changes:
* CI/CD: Lock mypy version because stubtest is failing on mypy 1.18.1