### PR TITLE
[CLIENT-2159] Fix potential memory leaks or errors related to client.batch_write() or ctx parameters

### DIFF
--- a/src/main/client/batch_write.c
+++ b/src/main/client/batch_write.c
@@ -62,11 +62,10 @@
                 as_error_update(err, AEROSPIKE_ERR_PARAM,                      \
                                 "batch_type: %s, policy must be a dict",       \
                                 __batch_type);                                 \
-                Py_DECREF(py___policy);                                        \
                 goto CLEANUP_ON_ERROR;                                         \
             }                                                                  \
         }                                                                      \
-        Py_DECREF(py___policy);                                                \
+        Py_XDECREF(py___policy);                                               \
     }
 
 // TODO replace this with type checking the batch_records
@@ -260,9 +259,7 @@ static PyObject *AerospikeClient_BatchWriteInvoke(AerospikeClient *self,
                                 "py_ops_list is NULL or not a list, %s must be "
                                 "a list of aerospike operation dicts",
                                 FIELD_NAME_BATCH_OPS);
-                // TODO: mem leak if ops is not a list?
-                // Fix later
-                goto CLEANUP1;
+                goto CLEANUP0;
             }
 
             // the batch record object had no ops attribute but some don't, so this is ok.
@@ -376,8 +373,8 @@ static PyObject *AerospikeClient_BatchWriteInvoke(AerospikeClient *self,
                 Py_XDECREF(py_mod);
                 goto CLEANUP_ON_ERROR;
             }
-            Py_DECREF(py_mod);
             const char *mod = PyUnicode_AsUTF8(py_mod);
+            Py_DECREF(py_mod);
 
             PyObject *py_func = PyObject_GetAttrString(
                 py_batch_record, FIELD_NAME_BATCH_FUNCTION);
@@ -387,8 +384,8 @@ static PyObject *AerospikeClient_BatchWriteInvoke(AerospikeClient *self,
                 Py_XDECREF(py_func);
                 goto CLEANUP_ON_ERROR;
             }
-            Py_DECREF(py_func);
             const char *func = PyUnicode_AsUTF8(py_func);
+            Py_DECREF(py_func);
 
             PyObject *py_args =
                 PyObject_GetAttrString(py_batch_record, FIELD_NAME_BATCH_ARGS);
@@ -403,11 +400,10 @@ static PyObject *AerospikeClient_BatchWriteInvoke(AerospikeClient *self,
             as_list *arglist = NULL;
             pyobject_to_list(self, err, py_args, &arglist, &static_pool,
                              SERIALIZER_PYTHON);
+            Py_DECREF(py_args);
             if (err->code != AEROSPIKE_OK) {
-                Py_DECREF(py_args);
                 goto CLEANUP_ON_ERROR;
             }
-            Py_DECREF(py_args);
             garb->udf_args_to_free = arglist;
 
             as_batch_apply_record *ar;
@@ -522,6 +518,7 @@ static PyObject *AerospikeClient_BatchWriteInvoke(AerospikeClient *self,
 
 CLEANUP_ON_ERROR:
     Py_XDECREF(py_meta);
+CLEANUP0:
     Py_XDECREF(py_ops_list);
 CLEANUP1:
     Py_XDECREF(py_batch_type);

--- a/src/main/conversions.c
+++ b/src/main/conversions.c
@@ -2747,12 +2747,18 @@ as_status get_cdt_ctx(AerospikeClient *self, as_error *err, as_cdt_ctx *cdt_ctx,
                       as_static_pool *static_pool, int serializer_type)
 {
     PyObject *py_ctx = PyDict_GetItemString(op_dict, CTX_KEY);
-    long int_val = 0;
-    as_val *val = NULL;
 
     if (!py_ctx) {
         return AEROSPIKE_OK;
     }
+
+    long int_val = 0;
+    as_val *val = NULL;
+
+    as_status status = 0;
+    PyObject *py_id = NULL;
+    PyObject *py_value = NULL;
+    PyObject *py_extra_args = NULL;
 
     if (PyList_Check(py_ctx)) {
         Py_ssize_t py_list_size = PyList_Size(py_ctx);
@@ -2761,44 +2767,49 @@ as_status get_cdt_ctx(AerospikeClient *self, as_error *err, as_cdt_ctx *cdt_ctx,
         for (int i = 0; i < py_list_size; i++) {
             PyObject *py_val = PyList_GetItem(py_ctx, (Py_ssize_t)i);
 
-            PyObject *id_temp = PyObject_GetAttrString(py_val, "id");
+            py_id = PyObject_GetAttrString(py_val, "id");
             if (PyErr_Occurred()) {
                 as_cdt_ctx_destroy(cdt_ctx);
-                return as_error_update(err, AEROSPIKE_ERR_PARAM,
-                                       "Failed to convert %s, id", CTX_KEY);
+                status = as_error_update(err, AEROSPIKE_ERR_PARAM,
+                                         "Failed to convert %s, id", CTX_KEY);
+                goto CLEANUP4;
             }
 
-            PyObject *value_temp = PyObject_GetAttrString(py_val, "value");
+            py_value = PyObject_GetAttrString(py_val, "value");
             if (PyErr_Occurred()) {
                 as_cdt_ctx_destroy(cdt_ctx);
-                return as_error_update(err, AEROSPIKE_ERR_PARAM,
-                                       "Failed to convert %s, value", CTX_KEY);
+                status =
+                    as_error_update(err, AEROSPIKE_ERR_PARAM,
+                                    "Failed to convert %s, value", CTX_KEY);
+                goto CLEANUP3;
             }
 
-            PyObject *extra_args_temp =
-                PyObject_GetAttrString(py_val, "extra_args");
+            py_extra_args = PyObject_GetAttrString(py_val, "extra_args");
             if (PyErr_Occurred()) {
                 as_cdt_ctx_destroy(cdt_ctx);
-                return as_error_update(err, AEROSPIKE_ERR_PARAM,
-                                       "Failed to convert %s", CTX_KEY);
+                status = as_error_update(err, AEROSPIKE_ERR_PARAM,
+                                         "Failed to convert %s", CTX_KEY);
+                goto CLEANUP2;
             }
 
-            uint64_t item_type = PyLong_AsUnsignedLongLong(id_temp);
+            uint64_t item_type = PyLong_AsUnsignedLongLong(py_id);
             if (PyErr_Occurred()) {
                 as_cdt_ctx_destroy(cdt_ctx);
-                return as_error_update(err, AEROSPIKE_ERR_PARAM,
-                                       "Failed to convert %s, id to uint64_t",
-                                       CTX_KEY);
+                status = as_error_update(err, AEROSPIKE_ERR_PARAM,
+                                         "Failed to convert %s, id to uint64_t",
+                                         CTX_KEY);
+                goto CLEANUP1;
             }
 
             // add an as_cdt_ctx with value to cdt_ctx
             if (requires_int(item_type)) {
-                int_val = PyLong_AsLong(value_temp);
+                int_val = PyLong_AsLong(py_value);
                 if (PyErr_Occurred()) {
                     as_cdt_ctx_destroy(cdt_ctx);
-                    return as_error_update(
+                    status = as_error_update(
                         err, AEROSPIKE_ERR_PARAM,
                         "Failed to convert %s, value to long", CTX_KEY);
+                    goto CLEANUP1;
                 }
                 switch (item_type) {
                 case AS_CDT_CTX_LIST_INDEX:
@@ -2816,28 +2827,30 @@ as_status get_cdt_ctx(AerospikeClient *self, as_error *err, as_cdt_ctx *cdt_ctx,
                 case CDT_CTX_LIST_INDEX_CREATE:;
                     int list_order = 0;
                     int pad = 0;
-                    get_int_from_py_dict(err, CDT_CTX_ORDER_KEY,
-                                         extra_args_temp, &list_order);
-                    get_int_from_py_dict(err, CDT_CTX_PAD_KEY, extra_args_temp,
+                    get_int_from_py_dict(err, CDT_CTX_ORDER_KEY, py_extra_args,
+                                         &list_order);
+                    get_int_from_py_dict(err, CDT_CTX_PAD_KEY, py_extra_args,
                                          &pad);
                     as_cdt_ctx_add_list_index_create(cdt_ctx, int_val,
                                                      list_order, pad);
                     break;
                 default:
                     as_cdt_ctx_destroy(cdt_ctx);
-                    return as_error_update(
+                    status = as_error_update(
                         err, AEROSPIKE_ERR_PARAM,
                         "Failed to convert, unknown ctx operation %s", CTX_KEY);
+                    goto CLEANUP1;
                 }
             }
             else {
-                if (as_val_new_from_pyobject(self, err, value_temp, &val,
+                if (as_val_new_from_pyobject(self, err, py_value, &val,
                                              static_pool,
                                              serializer_type) != AEROSPIKE_OK) {
                     as_cdt_ctx_destroy(cdt_ctx);
-                    return as_error_update(
+                    status = as_error_update(
                         err, AEROSPIKE_ERR_PARAM,
                         "Failed to convert %s, value to as_val", CTX_KEY);
+                    goto CLEANUP1;
                 }
                 switch (item_type) {
                 case AS_CDT_CTX_LIST_VALUE:
@@ -2851,30 +2864,41 @@ as_status get_cdt_ctx(AerospikeClient *self, as_error *err, as_cdt_ctx *cdt_ctx,
                     break;
                 case CDT_CTX_MAP_KEY_CREATE:;
                     int map_order = 0;
-                    get_int_from_py_dict(err, CDT_CTX_ORDER_KEY,
-                                         extra_args_temp, &map_order);
+                    get_int_from_py_dict(err, CDT_CTX_ORDER_KEY, py_extra_args,
+                                         &map_order);
                     as_cdt_ctx_add_map_key_create(cdt_ctx, val, map_order);
                     break;
                 default:
                     as_cdt_ctx_destroy(cdt_ctx);
-                    return as_error_update(
+                    status = as_error_update(
                         err, AEROSPIKE_ERR_PARAM,
                         "Failed to convert, unknown ctx operation %s", CTX_KEY);
+                    goto CLEANUP1;
                 }
             }
 
-            Py_DECREF(id_temp);
-            Py_DECREF(value_temp);
-            Py_XDECREF(extra_args_temp);
+            Py_DECREF(py_id);
+            Py_DECREF(py_value);
+            Py_DECREF(py_extra_args);
         }
     }
     else {
-        return as_error_update(err, AEROSPIKE_ERR_PARAM, "Failed to convert %s",
-                               CTX_KEY);
+        status = as_error_update(err, AEROSPIKE_ERR_PARAM,
+                                 "Failed to convert %s", CTX_KEY);
+        goto CLEANUP4;
     }
 
     *ctx_in_use = true;
     return AEROSPIKE_OK;
+
+CLEANUP1:
+    Py_DECREF(py_extra_args);
+CLEANUP2:
+    Py_DECREF(py_value);
+CLEANUP3:
+    Py_DECREF(py_id);
+CLEANUP4:
+    return status;
 }
 
 static bool requires_int(uint64_t op)

--- a/test/new_tests/test_nested_cdt_ctx.py
+++ b/test/new_tests/test_nested_cdt_ctx.py
@@ -162,7 +162,11 @@ class TestCTXOperations(object):
         assert bins[self.nested_list_bin] == expected
 
     @pytest.mark.parametrize(
-        "value, list_indexes, expected", [("toast", [2], e.OpNotApplicable), ("?", "cat", e.ParamError)]
+        "value, list_indexes, expected", [
+            ("toast", [2], e.OpNotApplicable),
+            # Passing in non-int values to a ctx object
+            ("?", "cat", e.ParamError)
+        ]
     )
     def test_ctx_list_append_negative(self, value, list_indexes, expected):
         """
@@ -287,7 +291,7 @@ class TestCTXOperations(object):
         "index, value, list_indexes, expected",
         [
             (1, "toast", [2], e.OpNotApplicable),
-            (0, "?", "cat", e.ParamError),
+            (0, "?", "cat", e.ParamError)
         ],
     )
     def test_ctx_list_insert_negative(self, index, value, list_indexes, expected):
@@ -4960,4 +4964,16 @@ class TestCTXOperations(object):
         ]
 
         with pytest.raises(expected):
+            self.as_connection.operate(self.test_key, ops)
+
+    def test_ctx_invalid_list_value(self):
+        # Python tuple has no server type
+        ctx = [
+            cdt_ctx.cdt_ctx_list_value((1, 2))
+        ]
+        ops = [
+            list_operations.list_append(self.nested_list_bin, "val1", None, ctx),
+        ]
+
+        with pytest.raises(e.ParamError):
             self.as_connection.operate(self.test_key, ops)


### PR DESCRIPTION
client.batch_write():
- Fix potential memory leak when an invalid list of operations is passed to an aerospike_helpers.batch.records.Write instance
- Fix seg fault if user passes in an instance of a BatchRecord subclass that doesn't have a "policy" attribute (user must have deleted the policy attribute from the instance on purpose to trigger this, though)

ctx parameter: fix potential memory leaks when user passes in an aerospike_helpers.cdt_ctx._cdt_ctx instance that either:
- Is missing the default class attributes
- Has an invalid _cdt_ctx.id or _cdt_ctx.value

Manual testing:
- massif usage looks ok
- valgrind shows no memory errors or leaks from these changes
- Build artifacts passes except for noise