### PR TITLE
[CLIENT-2452] Add default value for timeout parameter in info and admin policies

### DIFF
--- a/doc/client.rst
+++ b/doc/client.rst
@@ -2174,6 +2174,8 @@ Info Policies
 
         * **timeout** (:class:`int`)
             | Read timeout in milliseconds
+            |
+            | Default: ``1000``
 
 
 .. _aerospike_admin_policies:
@@ -2190,6 +2192,8 @@ Admin Policies
 
         * **timeout** (:class:`int`)
             | Admin operation timeout in milliseconds
+            |
+            | Default: ``1000``
 
 
 .. _aerospike_list_policies:


### PR DESCRIPTION
Added default "timeout" policy value for info and admin policies

https://aerospike-python-client--860.org.readthedocs.build/en/860/client.html#info-policies