### PR TITLE
[CLIENT-2791] Docs: add link to possible options for overflow behavior for the bit_{add,subtract} operations

### DIFF
--- a/aerospike_helpers/operations/bitwise_operations.py
+++ b/aerospike_helpers/operations/bitwise_operations.py
@@ -292,12 +292,6 @@ def bit_add(bin_name: str, bit_offset, bit_size, value, sign, action, policy=Non
         value (int): The value to be added.
         sign (bool): True: treat value as signed, False: treat value as unsigned.
         action (int): Action taken if an overflow/underflow occurs.
-            Action must be one of the following.
-
-            - :data:`aerospike.BIT_OVERFLOW_FAIL`
-            - :data:`aerospike.BIT_OVERFLOW_SATURATE`
-            - :data:`aerospike.BIT_OVERFLOW_WRAP`
-
             See :ref:`Bitwise Overflow <aerospike_bitwise_overflow>` for more information.
         policy (dict): The :ref:`bit_policy <aerospike_bit_policies>` dictionary. default: None.
 


### PR DESCRIPTION
Added links for possible values for overflow action parameters

## Docs

https://aerospike-python-client--862.org.readthedocs.build/en/862/aerospike_helpers.operations.html#aerospike_helpers.operations.bitwise_operations.bit_add
https://aerospike-python-client--862.org.readthedocs.build/en/862/aerospike_helpers.operations.html#aerospike_helpers.operations.bitwise_operations.bit_subtract

## TODO

- [x] Verify test cases cover this behavior