### PR TITLE
CI/CD: Fix dev-workflow-p2.yml bumping off master branch instead of dev

### DIFF
--- a/.github/workflows/dev-workflow-part2.yml
+++ b/.github/workflows/dev-workflow-part2.yml
@@ -2,7 +2,6 @@ name: Dev workflow (part 2)
 
 on:
   # This will ignore bump commits because those commits have [skip ci]
-  pull_request:
   push:
     branches:
     - 'dev*'
@@ -10,7 +9,6 @@ on:
 
 jobs:
   bump-dev-number:
-    if: ${{ false }}
     uses: ./.github/workflows/bump-version.yml
     with:
       change: 'bump-dev-num'


### PR DESCRIPTION
This started today because of a change made to pull_request_target by Github

I had to disable dev-workflow-p2.yml because whenever I merged a PR to dev, the original dev-workflow-p2.yml from the master branch would run (it has a pull_request_target trigger)

## TODO

- [x] Tested that merging a PR to dev-test triggers the workflow properly
- [x] Tested that running dev-workflow-part2.yml manually works
- [x] Deleted all tags from testing workflow