### PR TITLE
[CLIENT-4223] CI/CD: Fix run-ee-server composite action failing on Docker Engine API v1.52 or higher

### DIFF
--- a/.github/actions/run-ee-server/action.yml
+++ b/.github/actions/run-ee-server/action.yml
@@ -121,7 +121,7 @@ runs:
 
   - name: Set IP address to Docker container for the server
     if: ${{ inputs.where-is-client-connecting-from == 'separate-docker-container' }}
-    run: echo SERVER_IP=$(docker container inspect -f '{{ .NetworkSettings.IPAddress }}' ${{ steps.get-container-name.outputs.container-name }}) >> $GITHUB_ENV
+    run: echo SERVER_IP=$(docker container inspect -f '{{ .NetworkSettings.Networks.bridge.IPAddress }}' ${{ steps.get-container-name.outputs.container-name }}) >> $GITHUB_ENV
     shell: bash
 
   - name: Invalid input


### PR DESCRIPTION
Tested on #950 

pre-commit.ci and sphinx linkcheck failing, but not related to this change