### PR TITLE
[CLIENT-4224] CI/CD: Switch from using lint.yml to pre-commit.ci to run hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,8 +36,8 @@ repos:
     -   id: doc8
         args: ["doc/", "--extension", ".rst"]
         pass_filenames: false
--   repo: https://github.com/koalaman/shellcheck-precommit
-    rev: v0.11.0
+-   repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.11.0.1
     hooks:
     -   id: shellcheck
         # Running on all files causes this issue:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,3 @@
-ci:
-    skip: [shellcheck]
-
 repos:
 -   repo: https://github.com/pycqa/flake8
     rev: '6.0.0'  # pick a git hash / tag to point to

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+ci:
+    skip: [shellcheck]
+
 repos:
 -   repo: https://github.com/pycqa/flake8
     rev: '6.0.0'  # pick a git hash / tag to point to


### PR DESCRIPTION
pre-commit.ci will auto-update the hook versions every week, which is not supported in dependabot yet.

- Fix pre-commit.ci failing because it doesn't support Docker-based hooks yet. 
- Disabled lint.yaml workflow, since this replaces it