### PR TITLE
[CLIENT-4225] CI/CD: Remove unused delocate package from .github/workflows/requirements.txt

### DIFF
--- a/.github/workflows/requirements.txt
+++ b/.github/workflows/requirements.txt
@@ -1,4 +1,3 @@
 parver==0.5
 crudini==0.9.4
-delocate==0.10.4
 mypy==1.17.1


### PR DESCRIPTION
delocate is already installed by cibuildwheel. The cibuildwheel API docs isn't clear about this, but it is installed on both macos x86 and arm:

- https://github.com/aerospike/aerospike-client-python/actions/runs/22160394250/job/64076681306#step:22:336
- https://github.com/aerospike/aerospike-client-python/actions/runs/22160397839/job/64075398144#step:22:357

API docs also imply macOS and Linux have delocate and auditwheel available by default, respectively: https://cibuildwheel.pypa.io/en/stable/options/#:~:text=cibuildwheel%20doesn't%20yet%20ship%20a%20default%20repair%20command%20for%20Windows