### PR TITLE
[CLIENT-4334] Dev tests: replace all deprecated client.index_cdt_create() calls in test_cdt_index.py

### DIFF
--- a/src/main/client/sec_index.c
+++ b/src/main/client/sec_index.c
@@ -427,8 +427,8 @@ static PyObject *AerospikeClient_Index_Create_Deprecated_Helper(
     static char *kwlist[] = {"ns", "set", "bin", "name", "policy", NULL};
 
     // Python Function Argument Parsing
-    if (PyArg_ParseTupleAndKeywords(args, kwds, "OOOO|O:index_integer_create",
-                                    kwlist, &py_ns, &py_set, &py_bin, &py_name,
+    if (PyArg_ParseTupleAndKeywords(args, kwds, "OOOO|O", kwlist, &py_ns,
+                                    &py_set, &py_bin, &py_name,
                                     &py_policy) == false) {
         return NULL;
     }
@@ -498,10 +498,10 @@ PyObject *AerospikeClient_Index_Cdt_Create(AerospikeClient *self,
         "name", "ctx", "policy", NULL};
 
     // Python Function Argument Parsing
-    if (PyArg_ParseTupleAndKeywords(args, kwds, "OOOOOOO|O:index_list_create",
-                                    kwlist, &py_ns, &py_set, &py_bin,
-                                    &py_indextype, &py_datatype, &py_name,
-                                    &py_ctx, &py_policy) == false) {
+    if (PyArg_ParseTupleAndKeywords(args, kwds, "OOOOOOO|O", kwlist, &py_ns,
+                                    &py_set, &py_bin, &py_indextype,
+                                    &py_datatype, &py_name, &py_ctx,
+                                    &py_policy) == false) {
         return NULL;
     }
 

--- a/test/new_tests/test_cdt_index.py
+++ b/test/new_tests/test_cdt_index.py
@@ -96,15 +96,14 @@ class TestCDTIndex(object):
         Invoke index_cdt_create() with correct arguments
         """
         policy = {}
-        retobj = self.as_connection.index_cdt_create(
+        retobj = self.as_connection.index_list_create(
             "test",
             "demo",
             "string_list",
-            aerospike.INDEX_TYPE_LIST,
             aerospike.INDEX_STRING,
             "test_string_list_cdt_index",
-            ctx_list_index,
             policy,
+            ctx_list_index
         )
 
         self.as_connection.index_remove("test", "test_string_list_cdt_index", policy)
@@ -141,15 +140,14 @@ class TestCDTIndex(object):
         Invoke index_cdt_create() with correct arguments
         """
         policy = {}
-        retobj = self.as_connection.index_cdt_create(
+        retobj = self.as_connection.index_list_create(
             "test",
             "demo",
             "string_list",
-            aerospike.INDEX_TYPE_LIST,
             aerospike.INDEX_STRING,
             "test_string_list_cdt_index",
-            ctx_list_rank,
             policy,
+            ctx_list_rank
         )
 
         self.as_connection.index_remove("test", "test_string_list_cdt_index", policy)
@@ -162,15 +160,14 @@ class TestCDTIndex(object):
         Invoke index_cdt_create() with correct arguments
         """
         policy = {}
-        retobj = self.as_connection.index_cdt_create(
+        retobj = self.as_connection.index_list_create(
             "test",
             "demo",
             "string_list",
-            aerospike.INDEX_TYPE_LIST,
             aerospike.INDEX_STRING,
             "test_string_list_cdt_index",
-            ctx_list_value,
             policy,
+            ctx_list_value
         )
 
         self.as_connection.index_remove("test", "test_string_list_cdt_index", policy)
@@ -183,15 +180,14 @@ class TestCDTIndex(object):
         Invoke index_cdt_create() with correct arguments
         """
         policy = {}
-        retobj = self.as_connection.index_cdt_create(
+        retobj = self.as_connection.index_map_keys_create(
             "test",
             "demo",
             "string_list",
-            aerospike.INDEX_TYPE_MAPKEYS,
             aerospike.INDEX_STRING,
             "test_string_list_cdt_index",
-            ctx_map_index,
             policy,
+            ctx_map_index
         )
 
         self.as_connection.index_remove("test", "test_string_list_cdt_index", policy)
@@ -204,15 +200,14 @@ class TestCDTIndex(object):
         Invoke index_cdt_create() with correct arguments
         """
         policy = {}
-        retobj = self.as_connection.index_cdt_create(
+        retobj = self.as_connection.index_map_values_create(
             "test",
             "demo",
             "string_list",
-            aerospike.INDEX_TYPE_MAPVALUES,
             aerospike.INDEX_STRING,
             "test_string_list_cdt_index",
-            ctx_map_value,
             policy,
+            ctx_map_value
         )
 
         self.as_connection.index_remove("test", "test_string_list_cdt_index", policy)
@@ -225,15 +220,14 @@ class TestCDTIndex(object):
         Invoke index_cdt_create() with correct arguments
         """
         policy = {}
-        retobj = self.as_connection.index_cdt_create(
+        retobj = self.as_connection.index_map_values_create(
             "test",
             "demo",
             "string_list",
-            aerospike.INDEX_TYPE_MAPVALUES,
             aerospike.INDEX_STRING,
             "test_string_list_cdt_index",
-            ctx_map_rank,
             policy,
+            ctx_map_rank
         )
 
         self.as_connection.index_remove("test", "test_string_list_cdt_index", policy)
@@ -247,15 +241,14 @@ class TestCDTIndex(object):
         Invoke index_cdt_create() with correct arguments
         """
         policy = {}
-        retobj = self.as_connection.index_cdt_create(
+        retobj = self.as_connection.index_map_values_create(
             "test",
             "demo",
             "string_list",
-            aerospike.INDEX_TYPE_MAPVALUES,
             aerospike.INDEX_STRING,
             "test_string_list_cdt_index",
-            ctx_map_rank,
             policy,
+            ctx_map_rank
         )
 
         self.as_connection.index_remove("test", "test_string_list_cdt_index", policy)
@@ -268,15 +261,14 @@ class TestCDTIndex(object):
         Invoke index_cdt_create() with correct arguments
         """
         policy = {}
-        retobj = self.as_connection.index_cdt_create(
+        retobj = self.as_connection.index_list_create(
             "test",
             "demo",
             "numeric_list",
-            aerospike.INDEX_TYPE_LIST,
             aerospike.INDEX_NUMERIC,
             "test_numeric_list_cdt_index",
-            ctx_list_index,
             policy,
+            ctx_list_index
         )
 
         assert retobj == 0
@@ -291,15 +283,14 @@ class TestCDTIndex(object):
             set_name = set_name + "a"
         policy = {}
         try:
-            self.as_connection.index_cdt_create(
+            self.as_connection.index_list_create(
                 "test",
                 set_name,
                 "string_list",
-                aerospike.INDEX_TYPE_LIST,
                 aerospike.INDEX_STRING,
                 "test_string_list_cdt_index",
-                ctx_list_index,
                 policy,
+                ctx_list_index
             )
             assert False
         except e.InvalidRequest as exception:
@@ -312,15 +303,14 @@ class TestCDTIndex(object):
         Invoke createindex() with incorrect bin
         """
         policy = {}
-        retobj = self.as_connection.index_cdt_create(
+        retobj = self.as_connection.index_list_create(
             "test",
             "demo",
             "string_list1",
-            aerospike.INDEX_TYPE_LIST,
             aerospike.INDEX_STRING,
             "test_string_list_cdt_index",
-            ctx_list_index,
             policy,
+            ctx_list_index
         )
 
         assert retobj == 0
@@ -332,27 +322,25 @@ class TestCDTIndex(object):
         Invoke createindex() with multiple times on same bin
         """
         policy = {}
-        retobj = self.as_connection.index_cdt_create(
+        retobj = self.as_connection.index_list_create(
             "test",
             "demo",
             "numeric_list",
-            aerospike.INDEX_TYPE_LIST,
             aerospike.INDEX_NUMERIC,
             "test_numeric_list_cdt_index",
-            ctx_list_index,
             policy,
+            ctx_list_index
         )
         if retobj == 0:
             try:
-                self.as_connection.index_cdt_create(
+                self.as_connection.index_list_create(
                     "test",
                     "demo",
                     "numeric_list",
-                    aerospike.INDEX_TYPE_LIST,
                     aerospike.INDEX_NUMERIC,
                     "test_numeric_list_cdt_index",
-                    ctx_list_index,
                     policy,
+                    ctx_list_index
                 )
             except e.IndexFoundError:
                 assert self.server_version < [6, 1]
@@ -366,27 +354,25 @@ class TestCDTIndex(object):
         Invoke createindex() with multiple times on different bin
         """
         policy = {}
-        retobj = self.as_connection.index_cdt_create(
+        retobj = self.as_connection.index_list_create(
             "test",
             "demo",
             "string_list",
-            aerospike.INDEX_TYPE_LIST,
             aerospike.INDEX_STRING,
             "test_string_list_cdt_index",
-            ctx_list_index,
             policy,
+            ctx_list_index
         )
         if retobj == 0:
             with pytest.raises(e.IndexFoundError):
-                retobj = self.as_connection.index_cdt_create(
+                retobj = self.as_connection.index_list_create(
                     "test",
                     "demo",
                     "numeric_list",
-                    aerospike.INDEX_TYPE_LIST,
                     aerospike.INDEX_NUMERIC,
                     "test_string_list_cdt_index",
-                    ctx_list_index,
                     policy,
+                    ctx_list_index
                 )
                 self.as_connection.index_remove("test", "test_string_list_cdt_index", policy)
                 ensure_dropped_index(self.as_connection, "test", "test_string_list_cdt_index")
@@ -402,27 +388,25 @@ class TestCDTIndex(object):
         name
         """
         policy = {}
-        retobj = self.as_connection.index_cdt_create(
+        retobj = self.as_connection.index_list_create(
             "test",
             "demo",
             "string_list",
-            aerospike.INDEX_TYPE_LIST,
             aerospike.INDEX_STRING,
             "test_string_list_cdt_index",
-            ctx_list_index,
             policy,
+            ctx_list_index
         )
         if retobj == 0:
             try:
-                retobj = self.as_connection.index_cdt_create(
+                retobj = self.as_connection.index_list_create(
                     "test",
                     "demo",
                     "string_list",
-                    aerospike.INDEX_TYPE_LIST,
                     aerospike.INDEX_STRING,
                     "test_string_list_cdt_index1",
-                    ctx_list_index,
                     policy,
+                    ctx_list_index
                 )
             except e.IndexFoundError:
                 assert self.server_version < [6, 1]
@@ -437,15 +421,14 @@ class TestCDTIndex(object):
         Invoke createindex() with policy
         """
         policy = {"timeout": 10000}
-        retobj = self.as_connection.index_cdt_create(
+        retobj = self.as_connection.index_list_create(
             "test",
             "demo",
             "num_list_pol",
-            aerospike.INDEX_TYPE_LIST,
             aerospike.INDEX_NUMERIC,
             "test_numeric_list_cdt_index_pol",
-            ctx_list_index,
             policy,
+            ctx_list_index
         )
 
         assert retobj == 0
@@ -457,15 +440,14 @@ class TestCDTIndex(object):
         Invoke createindex() with policy
         """
         policy = {"timeout": 10000}
-        retobj = self.as_connection.index_cdt_create(
+        retobj = self.as_connection.index_list_create(
             "test",
             "demo",
             "string_list",
-            aerospike.INDEX_TYPE_LIST,
             aerospike.INDEX_STRING,
             "test_string_list_cdt_index",
-            ctx_list_index,
             policy,
+            ctx_list_index
         )
 
         assert retobj == 0
@@ -494,15 +476,14 @@ cfasdcalskdcbacfq34915rwcfasdcascnabscbaskjdbcalsjkbcdasc');
         Invoke create string index() with correct arguments
         """
         policy = {}
-        retobj = self.as_connection.index_cdt_create(
+        retobj = self.as_connection.index_list_create(
             "test",
             "demo",
             "string_list",
-            aerospike.INDEX_TYPE_LIST,
             aerospike.INDEX_STRING,
             "uni_name_index",
-            ctx_list_index,
             policy,
+            ctx_list_index
         )
 
         assert retobj == 0
@@ -514,15 +495,14 @@ cfasdcalskdcbacfq34915rwcfasdcascnabscbaskjdbcalsjkbcdasc');
         Invoke createindex() with correct arguments
         """
         policy = {}
-        retobj = self.as_connection.index_cdt_create(
+        retobj = self.as_connection.index_list_create(
             "test",
             "demo",
             "numeric_list",
-            aerospike.INDEX_TYPE_LIST,
             aerospike.INDEX_NUMERIC,
             "uni_age_index",
-            ctx_list_index,
             policy,
+            ctx_list_index
         )
 
         assert retobj == 0
@@ -550,15 +530,14 @@ cfasdcalskdcbacfq34915rwcfasdcascnabscbaskjdbcalsjkbcdasc');
         """
         policy = {}
         try:
-            self.as_connection.index_cdt_create(
+            self.as_connection.index_list_create(
                 None,
                 "demo",
                 "string_list",
-                aerospike.INDEX_TYPE_LIST,
                 aerospike.INDEX_STRING,
                 "test_string_list_cdt_index",
-                ctx_list_index,
                 policy,
+                ctx_list_index
             )
 
         except e.ParamError as exception:
@@ -571,15 +550,14 @@ cfasdcalskdcbacfq34915rwcfasdcascnabscbaskjdbcalsjkbcdasc');
         """
         policy = {}
         try:
-            self.as_connection.index_cdt_create(
+            self.as_connection.index_list_create(
                 "test",
                 1,
                 "string_list",
-                aerospike.INDEX_TYPE_LIST,
                 aerospike.INDEX_STRING,
                 "test_string_list_cdt_index",
-                ctx_list_index,
                 policy,
+                ctx_list_index
             )
             assert False
         except e.ParamError as exception:
@@ -594,15 +572,14 @@ cfasdcalskdcbacfq34915rwcfasdcascnabscbaskjdbcalsjkbcdasc');
         """
         policy = {}
         try:
-            self.as_connection.index_cdt_create(
+            self.as_connection.index_list_create(
                 "test",
                 None,
                 "string_list",
-                aerospike.INDEX_TYPE_LIST,
                 aerospike.INDEX_STRING,
                 "test_string_list_cdt_index",
-                ctx_list_index,
                 policy,
+                ctx_list_index
             )
 
         except e.ParamError as exception:
@@ -617,15 +594,14 @@ cfasdcalskdcbacfq34915rwcfasdcascnabscbaskjdbcalsjkbcdasc');
         """
         policy = {}
         try:
-            self.as_connection.index_cdt_create(
+            self.as_connection.index_list_create(
                 "test",
                 "demo",
                 None,
-                aerospike.INDEX_TYPE_LIST,
                 aerospike.INDEX_NUMERIC,
                 "test_numeric_list_cdt_index",
-                ctx_list_index,
                 policy,
+                ctx_list_index
             )
 
         except e.ParamError as exception:
@@ -638,15 +614,14 @@ cfasdcalskdcbacfq34915rwcfasdcascnabscbaskjdbcalsjkbcdasc');
         """
         policy = {}
         try:
-            self.as_connection.index_cdt_create(
+            self.as_connection.index_list_create(
                 "test",
                 "demo",
                 "string_list",
-                aerospike.INDEX_TYPE_LIST,
                 aerospike.INDEX_STRING,
                 None,
-                ctx_list_index,
                 policy,
+                ctx_list_index
             )
 
         except e.ParamError as exception:
@@ -660,15 +635,14 @@ cfasdcalskdcbacfq34915rwcfasdcascnabscbaskjdbcalsjkbcdasc');
         policy = {}
 
         try:
-            self.as_connection.index_cdt_create(
+            self.as_connection.index_single_value_create(
                 "test1",
                 "demo",
                 "numeric_list",
-                aerospike.INDEX_TYPE_DEFAULT,
                 aerospike.INDEX_NUMERIC,
                 "test_numeric_list_cdt_index",
-                ctx_list_index,
                 policy,
+                ctx_list_index
             )
 
         except e.NamespaceNotFound as exception:
@@ -679,15 +653,14 @@ cfasdcalskdcbacfq34915rwcfasdcascnabscbaskjdbcalsjkbcdasc');
         Invoke createindex() with incorrect set
         """
         policy = {}
-        retobj = self.as_connection.index_cdt_create(
+        retobj = self.as_connection.index_list_create(
             "test",
             "demo1",
             "numeric_list",
-            aerospike.INDEX_TYPE_LIST,
             aerospike.INDEX_NUMERIC,
             "test_numeric_list_cdt_index",
-            ctx_list_index,
             policy,
+            ctx_list_index
         )
 
         assert retobj == 0
@@ -704,46 +677,15 @@ cfasdcalskdcbacfq34915rwcfasdcascnabscbaskjdbcalsjkbcdasc');
         client1.close()
 
         try:
-            client1.index_cdt_create(
+            client1.index_list_create(
                 "test",
                 "demo",
                 "string_list",
-                aerospike.INDEX_TYPE_LIST,
                 aerospike.INDEX_STRING,
                 "test_string_list_cdt_index",
-                ctx_list_index,
                 policy,
+                ctx_list_index
             )
 
         except e.ClusterError as exception:
             assert exception.code == 11
-
-    def test_neg_cdtindex_with_no_paramters(self):
-        """
-        Invoke index_cdt_create() without any mandatory parameters.
-        """
-        with pytest.raises(TypeError) as typeError:
-            self.as_connection.index_cdt_create()
-
-        assert "argument 'ns' (pos 1)" in str(typeError.value)
-
-    @pytest.mark.parametrize(
-        "ctx",
-        [
-            None,
-            # Invalid type
-            {"ctx": 1}
-        ]
-    )
-    def test_neg_cdtindex_with_invalid_ctx(self, ctx):
-        with pytest.raises(e.ParamError):
-            self.as_connection.index_cdt_create(
-                "test",
-                "demo",
-                "string_list",
-                aerospike.INDEX_TYPE_LIST,
-                aerospike.INDEX_STRING,
-                "test_string_list_cdt_index",
-                # Ctx must be a list
-                ctx
-            )

--- a/test/new_tests/test_index_deprecated.py
+++ b/test/new_tests/test_index_deprecated.py
@@ -24,10 +24,8 @@ class TestDeprecatedIndexCreationMethods:
 
     def test_index_cdt_create_raises_warning(self):
         with pytest.warns(DeprecationWarning):
-            try:
-                self.as_connection.index_cdt_create("test", "demo", "bin", aerospike.INDEX_TYPE_DEFAULT, aerospike.INDEX_NUMERIC, [])
-            except:
-                pass
+            with pytest.raises(e.ParamError):
+                self.as_connection.index_cdt_create("test", "demo", "bin", aerospike.INDEX_TYPE_DEFAULT, aerospike.INDEX_NUMERIC, 2)
 
     def test_neg_cdtindex_with_no_paramters(self):
         """
@@ -36,8 +34,7 @@ class TestDeprecatedIndexCreationMethods:
         with pytest.warns(DeprecationWarning):
             with pytest.raises(TypeError) as typeError:
                 self.as_connection.index_cdt_create()
-
-        assert "argument 'ns' (pos 1)" in str(typeError.value)
+            assert "argument 'ns' (pos 1)" in str(typeError.value)
 
     @pytest.mark.parametrize(
         "ctx",

--- a/test/new_tests/test_index_deprecated.py
+++ b/test/new_tests/test_index_deprecated.py
@@ -33,8 +33,9 @@ class TestDeprecatedIndexCreationMethods:
         """
         Invoke index_cdt_create() without any mandatory parameters.
         """
-        with pytest.raises(TypeError) as typeError:
-            self.as_connection.index_cdt_create()
+        with pytest.warns(DeprecationWarning):
+            with pytest.raises(TypeError) as typeError:
+                self.as_connection.index_cdt_create()
 
         assert "argument 'ns' (pos 1)" in str(typeError.value)
 
@@ -47,14 +48,15 @@ class TestDeprecatedIndexCreationMethods:
         ]
     )
     def test_neg_cdtindex_with_invalid_ctx(self, ctx):
-        with pytest.raises(e.ParamError):
-            self.as_connection.index_cdt_create(
-                "test",
-                "demo",
-                "string_list",
-                aerospike.INDEX_TYPE_LIST,
-                aerospike.INDEX_STRING,
-                "test_string_list_cdt_index",
-                # Ctx must be a list
-                ctx
-            )
+        with pytest.warns(DeprecationWarning):
+            with pytest.raises(e.ParamError):
+                self.as_connection.index_cdt_create(
+                    "test",
+                    "demo",
+                    "string_list",
+                    aerospike.INDEX_TYPE_LIST,
+                    aerospike.INDEX_STRING,
+                    "test_string_list_cdt_index",
+                    # Ctx must be a list
+                    ctx
+                )

--- a/test/new_tests/test_index_deprecated.py
+++ b/test/new_tests/test_index_deprecated.py
@@ -13,6 +13,7 @@ class TestDeprecatedIndexCreationMethods:
             aerospike.Client.index_integer_create,
             aerospike.Client.index_string_create,
             aerospike.Client.index_geo2dsphere_create,
+            aerospike.Client.index_cdt_create,
         ]
     )
     def test_deprecated_index_creation_methods(self, index_create_method):
@@ -21,3 +22,33 @@ class TestDeprecatedIndexCreationMethods:
             with pytest.raises(e.ParamError):
                 index_create_method(self.as_connection, 1, "demo", "bin_name", "deprecated_index")
         assert len(w) == 1
+
+    def test_neg_cdtindex_with_no_paramters(self):
+        """
+        Invoke index_cdt_create() without any mandatory parameters.
+        """
+        with pytest.raises(TypeError) as typeError:
+            self.as_connection.index_cdt_create()
+
+        assert "argument 'ns' (pos 1)" in str(typeError.value)
+
+    @pytest.mark.parametrize(
+        "ctx",
+        [
+            None,
+            # Invalid type
+            {"ctx": 1}
+        ]
+    )
+    def test_neg_cdtindex_with_invalid_ctx(self, ctx):
+        with pytest.raises(e.ParamError):
+            self.as_connection.index_cdt_create(
+                "test",
+                "demo",
+                "string_list",
+                aerospike.INDEX_TYPE_LIST,
+                aerospike.INDEX_STRING,
+                "test_string_list_cdt_index",
+                # Ctx must be a list
+                ctx
+            )

--- a/test/new_tests/test_index_deprecated.py
+++ b/test/new_tests/test_index_deprecated.py
@@ -22,14 +22,10 @@ class TestDeprecatedIndexCreationMethods:
                 index_create_method(self.as_connection, 1, "demo", "bin_name", "deprecated_index")
         assert len(w) == 1
 
-    def test_index_cdt_create_raises_warning(self):
-        with pytest.warns(DeprecationWarning):
-            with pytest.raises(e.ParamError):
-                self.as_connection.index_cdt_create("test", "demo", "bin", aerospike.INDEX_TYPE_DEFAULT, aerospike.INDEX_NUMERIC, 2)
-
     def test_neg_cdtindex_with_no_paramters(self):
         """
         Invoke index_cdt_create() without any mandatory parameters.
+        Also test that this API call raises a warning.
         """
         with pytest.warns(DeprecationWarning):
             with pytest.raises(TypeError) as typeError:

--- a/test/new_tests/test_index_deprecated.py
+++ b/test/new_tests/test_index_deprecated.py
@@ -13,7 +13,6 @@ class TestDeprecatedIndexCreationMethods:
             aerospike.Client.index_integer_create,
             aerospike.Client.index_string_create,
             aerospike.Client.index_geo2dsphere_create,
-            aerospike.Client.index_cdt_create,
         ]
     )
     def test_deprecated_index_creation_methods(self, index_create_method):
@@ -22,6 +21,13 @@ class TestDeprecatedIndexCreationMethods:
             with pytest.raises(e.ParamError):
                 index_create_method(self.as_connection, 1, "demo", "bin_name", "deprecated_index")
         assert len(w) == 1
+
+    def test_index_cdt_create_raises_warning(self):
+        with pytest.warns(DeprecationWarning):
+            try:
+                self.as_connection.index_cdt_create("test", "demo", "bin", aerospike.INDEX_TYPE_DEFAULT, aerospike.INDEX_NUMERIC, [])
+            except:
+                pass
 
     def test_neg_cdtindex_with_no_paramters(self):
         """

--- a/test/new_tests/test_log.py
+++ b/test/new_tests/test_log.py
@@ -13,7 +13,7 @@ def custom_log_callback(level, func, path, line, msg):
     callback_called = True
 
 class TestLog(object):
-    @pytest.mark.fixture(autouse=True)
+    @pytest.fixture(autouse=True)
     def setup(self):
         global callback_called
         callback_called = False

--- a/test/new_tests/test_operate_helpers.py
+++ b/test/new_tests/test_operate_helpers.py
@@ -311,17 +311,22 @@ class TestOperate(object):
         assert bins == {"name": "name1aa"}
 
     @pytest.mark.parametrize(
-        "key, llist", [(("test", "demo", 1), [operations.touch(4000)]), (("test", "demo", 1), [operations.touch(4000)])]
+        "key", [
+            ("test", "demo", 1)
+        ]
     )
-    def test_pos_operate_touch_operation_with_bin_and_value_combination(self, key, llist):
+    def test_pos_operate_touch_operation_with_bin_and_value_combination(self, key):
         """
         Invoke operate() with touch value with bin and value combination.
         """
 
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter(action="always", category=DeprecationWarning)
-            self.as_connection.operate(key, llist)
-        assert len(w) == 2
+            ops = [
+                operations.touch(4000)
+            ]
+        assert len(w) == 1
+        self.as_connection.operate(key, ops)
 
         (key, meta) = self.as_connection.exists(key)
 

--- a/test/new_tests/test_operate_helpers.py
+++ b/test/new_tests/test_operate_helpers.py
@@ -5,6 +5,7 @@ from aerospike_helpers.operations import list_operations, operations
 
 import aerospike
 from aerospike import exception as e
+import warnings
 
 # OPERATIONS
 # aerospike.OPERATOR_WRITE
@@ -317,7 +318,10 @@ class TestOperate(object):
         Invoke operate() with touch value with bin and value combination.
         """
 
-        self.as_connection.operate(key, llist)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter(action="always", category=DeprecationWarning)
+            self.as_connection.operate(key, llist)
+        assert len(w) == 2
 
         (key, meta) = self.as_connection.exists(key)
 


### PR DESCRIPTION
## Extra changes

- Remove misleading function name in error messages for deprecated index creation APIs
- Check that client.index_cdt_create() raises a warning
- Fix test_log.py not properly resetting flag before running each test case
- Check warning for operation.touch()'s ttl parameter