### PR TITLE
[CLIENT-4425] Docs: fix invalid cross references (unrelated to type aliases)

### DIFF
--- a/aerospike_helpers/batch/records.py
+++ b/aerospike_helpers/batch/records.py
@@ -127,7 +127,7 @@ class Read(BatchRecord):
             ops (:ref:`aerospike_operation_helpers.operations`): list of aerospike operation dictionaries to perform on
                 the record at key.
             meta (dict): the metadata to set for this command
-            read_all_bins (bool, optional): An optional bool, if True, read all bins in the record.
+            read_all_bins (:obj:`bool`, optional): An optional bool, if True, read all bins in the record.
             policy (:ref:`aerospike_batch_read_policies`, optional): An optional dictionary of batch read policy flags.
     """
 

--- a/aerospike_helpers/batch/records.py
+++ b/aerospike_helpers/batch/records.py
@@ -38,8 +38,9 @@ class BatchRecord:
 
         BatchRecord should usually be read from as a result and not created by the user. Its subclasses can be used as
         input to batch_write.
-        Client methods :meth:`~Client.batch_apply`, :meth:`~Client.batch_operate`, :meth:`~Client.batch_remove`
-        with batch_records field as a list of these BatchRecord objects containing the batch request results.
+        Client methods :meth:`~aerospike.Client.batch_apply`, :meth:`~aerospike.Client.batch_operate`,
+        :meth:`~aerospike.Client.batch_remove` with batch_records field as a list of these BatchRecord objects
+        containing the batch request results.
 
         Attributes:
             key (:obj:`tuple`): The aerospike key to operate on.

--- a/aerospike_helpers/cdt_ctx.py
+++ b/aerospike_helpers/cdt_ctx.py
@@ -115,6 +115,9 @@ These :py:class:`_cdt_ctx` methods are meant to be used with path expressions:
 """
 import aerospike
 
+# Somehow sphinx-autodoc-typehints isn't setting TYPE_CHECKING to true, so there's a
+# NameError when using Any
+from typing import Any
 
 def index_type_string(index_type):
     """
@@ -299,7 +302,7 @@ def cdt_ctx_map_value(value):
     return _cdt_ctx(id=aerospike.CDT_CTX_MAP_VALUE, value=value)
 
 
-def cdt_ctx_map_key_create(key: any, order: int = 0) -> _cdt_ctx:
+def cdt_ctx_map_key_create(key: Any, order: int = 0) -> _cdt_ctx:
     """
     Create a map with the given sort order at the given key.
 

--- a/aerospike_helpers/expressions/arithmetic.py
+++ b/aerospike_helpers/expressions/arithmetic.py
@@ -390,7 +390,7 @@ class ToFloat(_BaseExpr):
 class Min(_BaseExpr):
     """
     Create expression that returns the minimum value in a variable number of expressions.
-        All arguments must be the same type (integer or float).
+    All arguments must be the same type (integer or float).
 
     Requires server version 5.6.0+.
     """
@@ -400,7 +400,7 @@ class Min(_BaseExpr):
     def __init__(self, *args: "TypeNumber"):
         """Args:
             `*args` (TypeNumber): Variable amount of float or integer expressions or values from which to find the
-            minimum value.
+                minimum value.
 
         :return: (integer or float value).
 

--- a/aerospike_helpers/expressions/arithmetic.py
+++ b/aerospike_helpers/expressions/arithmetic.py
@@ -390,7 +390,7 @@ class ToFloat(_BaseExpr):
 class Min(_BaseExpr):
     """
     Create expression that returns the minimum value in a variable number of expressions.
-    All arguments must be the same type (integer or float).
+        All arguments must be the same type (integer or float).
 
     Requires server version 5.6.0+.
     """
@@ -424,7 +424,7 @@ class Max(_BaseExpr):
     def __init__(self, *args: "TypeNumber"):
         """Args:
             `*args` (TypeNumber): Variable amount of float or integer expressions or values from which to find the
-            maximum value.
+                maximum value.
 
         :return: (integer or float value).
 

--- a/aerospike_helpers/expressions/base.py
+++ b/aerospike_helpers/expressions/base.py
@@ -1006,7 +1006,7 @@ class Let(_BaseExpr):
     def __init__(self, *exprs: _BaseExpr):
         """Args:
             `*exprs` (_BaseExpr): Variable number of :class:`~aerospike_helpers.expressions.base.Def` expressions
-            followed by a scoped expression.
+                followed by a scoped expression.
 
         :return: (result of scoped expression)
 

--- a/aerospike_helpers/expressions/bitwise.py
+++ b/aerospike_helpers/expressions/bitwise.py
@@ -622,7 +622,7 @@ class BitLeftScan(_BaseExpr):
         """Args:
             bit_offset (int): Bit index of where to start reading.
             bit_size (int): Number of bits to read.
-            value bool: Bit value to check for.
+            value (bool): Bit value to check for.
             bin (TypeBinName): A :class:`~aerospike_helpers.expressions.base.BlobBin` expression.
 
         :return: Index of the left most bit starting from bit_offset set to value. Returns -1 if not found.
@@ -672,7 +672,7 @@ class BitGetInt(_BaseExpr):
         """Args:
             bit_offset (int): Bit index of where to start reading.
             bit_size (int): Number of bits to get.
-            sign bool: True for signed, False for unsigned.
+            sign (bool): True for signed, False for unsigned.
             bin (TypeBinName): A :class:`~aerospike_helpers.expressions.base.BlobBin` expression.
 
         :return: Integer expression.

--- a/aerospike_helpers/expressions/resources.py
+++ b/aerospike_helpers/expressions/resources.py
@@ -143,7 +143,8 @@ TypeResultType = Optional[int]
 TypeFixedEle = Union[int, float, str, bytes, dict]
 TypeFixed = Optional[Dict[str, TypeFixedEle]]
 TypeCompiledOp = Tuple[int, TypeResultType, TypeFixed, int]
-_TypeExpression = List[TypeCompiledOp]
+
+TypeExpression = List[TypeCompiledOp]
 
 TypeChild = Union[int, float, str, bytes, _AtomExpr]
 TypeChildren = Tuple[TypeChild, ...]
@@ -171,7 +172,7 @@ class _BaseExpr(_AtomExpr):
             0,
         )
 
-    def compile(self) -> _TypeExpression:
+    def compile(self) -> TypeExpression:
         """
         Returns an expression object that can be passed to the Python client API.
         """

--- a/aerospike_helpers/expressions/resources.py
+++ b/aerospike_helpers/expressions/resources.py
@@ -143,6 +143,7 @@ TypeResultType = Optional[int]
 TypeFixedEle = Union[int, float, str, bytes, dict]
 TypeFixed = Optional[Dict[str, TypeFixedEle]]
 TypeCompiledOp = Tuple[int, TypeResultType, TypeFixed, int]
+
 #: Compiled expression that can be passed to the Python client API.
 TypeExpression = List[TypeCompiledOp]
 

--- a/aerospike_helpers/expressions/resources.py
+++ b/aerospike_helpers/expressions/resources.py
@@ -2,7 +2,7 @@
 Resources used by all expressions.
 """
 
-# from __future__ import annotations
+from __future__ import annotations
 from itertools import chain
 from typing import List, Optional, Tuple, Union, Dict, Any
 

--- a/aerospike_helpers/expressions/resources.py
+++ b/aerospike_helpers/expressions/resources.py
@@ -143,7 +143,7 @@ TypeResultType = Optional[int]
 TypeFixedEle = Union[int, float, str, bytes, dict]
 TypeFixed = Optional[Dict[str, TypeFixedEle]]
 TypeCompiledOp = Tuple[int, TypeResultType, TypeFixed, int]
-
+#: Compiled expression that can be passed to the Python client API.
 TypeExpression = List[TypeCompiledOp]
 
 TypeChild = Union[int, float, str, bytes, _AtomExpr]

--- a/aerospike_helpers/expressions/resources.py
+++ b/aerospike_helpers/expressions/resources.py
@@ -143,7 +143,7 @@ TypeResultType = Optional[int]
 TypeFixedEle = Union[int, float, str, bytes, dict]
 TypeFixed = Optional[Dict[str, TypeFixedEle]]
 TypeCompiledOp = Tuple[int, TypeResultType, TypeFixed, int]
-TypeExpression = List[TypeCompiledOp]
+_TypeExpression = List[TypeCompiledOp]
 
 TypeChild = Union[int, float, str, bytes, _AtomExpr]
 TypeChildren = Tuple[TypeChild, ...]
@@ -171,7 +171,7 @@ class _BaseExpr(_AtomExpr):
             0,
         )
 
-    def compile(self) -> TypeExpression:
+    def compile(self) -> _TypeExpression:
         """
         Returns an expression object that can be passed to the Python client API.
         """

--- a/aerospike_helpers/expressions/resources.py
+++ b/aerospike_helpers/expressions/resources.py
@@ -152,6 +152,9 @@ TypeAny = Union[_AtomExpr, Any]
 
 
 class _BaseExpr(_AtomExpr):
+    """
+    Base class for all expressions.
+    """
     _op: int = 0
     _rt: TypeResultType = None
     _fixed: TypeFixed = None

--- a/aerospike_helpers/expressions/resources.py
+++ b/aerospike_helpers/expressions/resources.py
@@ -172,6 +172,9 @@ class _BaseExpr(_AtomExpr):
         )
 
     def compile(self) -> TypeExpression:
+        """
+        Returns an expression object that can be passed to the Python client API.
+        """
         expression = [self._get_op()]
         work = chain(self._children)
 

--- a/aerospike_helpers/operations/bitwise_operations.py
+++ b/aerospike_helpers/operations/bitwise_operations.py
@@ -158,7 +158,8 @@ ACTION_KEY = "action"
 
 
 def bit_resize(bin_name: str, byte_size, policy=None, resize_flags: int = 0):
-    """Creates a bit_resize_operation to be used with :meth:`aerospike.operate` or :meth:`aerospike.operate_ordered`.
+    """Creates a bit_resize_operation to be used with :meth:`aerospike.Client.operate` or
+        :meth:`aerospike.Client.operate_ordered`.
 
     Change the size of a bytes bin stored in a record on the Aerospike Server.
 
@@ -184,7 +185,8 @@ def bit_resize(bin_name: str, byte_size, policy=None, resize_flags: int = 0):
 
 
 def bit_remove(bin_name: str, byte_offset, byte_size, policy=None):
-    """Creates a bit_remove_operation to be used with :meth:`aerospike.operate` or :meth:`aerospike.operate_ordered`.
+    """Creates a bit_remove_operation to be used with :meth:`aerospike.Client.operate` or
+        :meth:`aerospike.Client.operate_ordered`.
 
     Remove bytes from bitmap at byte_offset for byte_size.
 
@@ -208,7 +210,8 @@ def bit_remove(bin_name: str, byte_offset, byte_size, policy=None):
 
 
 def bit_set(bin_name: str, bit_offset, bit_size, value_byte_size, value, policy=None):
-    """Creates a bit_set_operation to be used with :meth:`aerospike.operate` or :meth:`aerospike.operate_ordered`.
+    """Creates a bit_set_operation to be used with :meth:`aerospike.Client.operate` or
+        :meth:`aerospike.Client.operate_ordered`.
 
     Set the value on a bitmap at bit_offset for bit_size in a record on the Aerospike Server.
 
@@ -236,7 +239,8 @@ def bit_set(bin_name: str, bit_offset, bit_size, value_byte_size, value, policy=
 
 
 def bit_set_int(bin_name: str, bit_offset: int, bit_size: int, value: int, policy: dict = None):
-    """Creates a bit_set_int_operation to be used with :meth:`aerospike.operate` or :meth:`aerospike.operate_ordered`.
+    """Creates a bit_set_int_operation to be used with :meth:`aerospike.Client.operate` or
+        :meth:`aerospike.Client.operate_ordered`.
 
     Set the value on a bitmap starting at bit_offset for bit_size in a record on the Aerospike Server.
 
@@ -262,7 +266,8 @@ def bit_set_int(bin_name: str, bit_offset: int, bit_size: int, value: int, polic
 
 
 def bit_count(bin_name: str, bit_offset, bit_size):
-    """Creates a bit_count_operation to be used with :meth:`aerospike.operate` or :meth:`aerospike.operate_ordered`.
+    """Creates a bit_count_operation to be used with :meth:`aerospike.Client.operate` or
+        :meth:`aerospike.Client.operate_ordered`.
 
     Server returns an integer count of all set bits starting at bit_offset for bit_size bits.
 
@@ -501,7 +506,7 @@ def bit_or(bin_name: str, bit_offset, bit_size, value_byte_size, value, policy=N
         bit_offset (int): The offset where the bits will start being compared.
         bit_size (int): How many bits of value to or.
         value_byte_size (int): Length of value in bytes.
-        value (bytes/byte array): Value to be used in or operation.
+        value (bytes | bytearray): Value to be used in or operation.
         policy (dict): The :ref:`bit_policy <aerospike_bit_policies>` dictionary. default: None.
 
     Returns:
@@ -618,7 +623,7 @@ def bit_xor(bin_name: str, bit_offset, bit_size, value_byte_size, value, policy=
         bit_offset (int): The offset where the bits will start being compared.
         bit_size (int): How many bits of value to xor.
         value_byte_size (int): Length of value in bytes.
-        value (bytes/byte array): Value to be used in xor operation.
+        value (bytes | bytearray): Value to be used in xor operation.
         policy (dict): The :ref:`bit_policy <aerospike_bit_policies>` dictionary. default: None.
 
     Returns:

--- a/doc/aerospike.rst
+++ b/doc/aerospike.rst
@@ -208,7 +208,7 @@ Serialization
     Register a user-defined serializer available to all `Client`
     instances.
 
-    :param typing.Callable callback: the function to invoke for serialization.
+    :param Callable callback: the function to invoke for serialization.
 
 
     .. seealso:: To use this function with :meth:`Client.put`, \

--- a/doc/aerospike.rst
+++ b/doc/aerospike.rst
@@ -208,7 +208,7 @@ Serialization
     Register a user-defined serializer available to all `Client`
     instances.
 
-    :param Callable callback: the function to invoke for serialization.
+    :param typing.Callable callback: the function to invoke for serialization.
 
 
     .. seealso:: To use this function with :meth:`Client.put`, \

--- a/doc/aerospike.rst
+++ b/doc/aerospike.rst
@@ -208,7 +208,7 @@ Serialization
     Register a user-defined serializer available to all `Client`
     instances.
 
-    :param callable callback: the function to invoke for serialization.
+    :param typing.Callable callback: the function to invoke for serialization.
 
 
     .. seealso:: To use this function with :meth:`Client.put`, \
@@ -232,7 +232,7 @@ Serialization
     of type `AS_BYTES_BLOB <http://www.aerospike.com/apidocs/c/d0/dd4/as__bytes_8h.html#a0cf2a6a1f39668f606b19711b3a98bf3>`_
     through this deserializer.
 
-    :param callable callback: the function to invoke for deserialization.
+    :param typing.Callable callback: the function to invoke for deserialization.
 
 .. py:function:: unset_serializers()
 
@@ -313,7 +313,7 @@ The following example shows several different methods to configuring logging for
         def callback(level: int, function: str, path: str, line: int, message: str):
             pass
 
-    :param optional callable log_handler: the function used as the logging handler.
+    :param typing.Callable | None log_handler: the function used as the logging handler.
 
 .. py:function:: set_log_level(loglevel)
 
@@ -432,7 +432,7 @@ Only the `hosts` key is required; the rest of the keys are optional.
             server configuration file, as well as the server's CA certificate.
 
         * **user** (:class:`str`)
-            (Optional) A defined user with roles in the cluster. See :meth:`admin_create_user`.
+            (Optional) A defined user with roles in the cluster. See :meth:`aerospike.Client.admin_create_user`.
         * **password** (:class:`str`)
             (Optional) The password will be hashed by the client using bcrypt.
         * **config_provider** (:class:`aerospike.ConfigProvider`)
@@ -782,14 +782,14 @@ Only the `hosts` key is required; the rest of the keys are optional.
             Compress data for transmission if the object size is greater than a given number of bytes
 
             Default: ``0``, meaning 'never compress'
-        * **cluster_name** (:class:`Optional[str]`)
+        * **cluster_name** (:class:`str` | :class:`None`)
             Expected cluster name. If set to a string value, the ``cluster_name`` must match the cluster-name field
             in the service section in each server configuration. This ensures that the specified
             seed nodes belong to the expected cluster on startup. If not, the client will refuse
             to add the node to the client's view of the cluster.
 
             Default: :py:obj:`None`
-        * **app_id** (:class:`Optional[str]`)
+        * **app_id** (:class:`str` | :class:`None`)
             Application identifier.
 
             If this is set to :py:obj:`None`, this is set to the client's username by default. If client doesn't have a username,
@@ -1721,7 +1721,7 @@ Permission codes define the type of permission granted for a user's role.
 
 Regex Flag Values
 ------------------
-Flags used by the :class:`aerospike_operation_helpers.expressions.base.CmpRegex` Aerospike expression.
+Flags used by the :class:`aerospike_helpers.expressions.base.CmpRegex` Aerospike expression.
 See :ref:`aerospike_operation_helpers.expressions` for more information.
 
 .. data:: REGEX_NONE
@@ -1861,7 +1861,7 @@ Path Expression Select Flags
     This is a synonym for :data:`aerospike.EXP_PATH_SELECT_VALUE` to make it clear in your
     source code that you're expecting a map.  See also :data:`aerospike.EXP_PATH_SELECT_MAP_KEY_VALUE`.
 
-.. data:: EXP_PATH_SELECT_MAP_KEYS
+.. data:: EXP_PATH_SELECT_MAP_KEY
 
     Return the list of map keys of the nodes finally selected by the context.
 

--- a/doc/aerospike_helpers.batch.rst
+++ b/doc/aerospike_helpers.batch.rst
@@ -6,8 +6,8 @@ aerospike\_helpers\.batch package
 aerospike\_helpers\.batch\.records module
 -----------------------------------------
 
-Classes for the use with client batch APIs :meth:`~Client.batch_write`, :meth:`~Client.batch_operate`,
-:meth:`~Client.batch_apply`, :meth:`~Client.batch_remove`.
+Classes for the use with client batch APIs :meth:`~aerospike.Client.batch_write`,
+:meth:`~aerospike.Client.batch_operate`, :meth:`~aerospike.Client.batch_apply`, :meth:`~aerospike.Client.batch_remove`.
 
 .. automodule:: aerospike_helpers.batch.records
     :members:

--- a/doc/aerospike_helpers.cdt_ctx.rst
+++ b/doc/aerospike_helpers.cdt_ctx.rst
@@ -9,3 +9,4 @@ aerospike\_helpers\.cdt_ctx module
     :members:
     :undoc-members:
     :show-inheritance:
+    :private-members: _cdt_ctx

--- a/doc/aerospike_helpers.expressions.rst
+++ b/doc/aerospike_helpers.expressions.rst
@@ -20,7 +20,8 @@ In the Python client, Aerospike expressions are built using a series of classes 
 comparison and logical operators, bins, metadata operations, and bin operations.
 Expressions are constructed using a Lisp like syntax by instantiating an expression that yields a boolean,
 such as :meth:`~aerospike_helpers.expressions.base.Eq` or :meth:`~aerospike_helpers.expressions.base.And`,
-while passing them other expressions and constants as arguments, and finally calling the :meth:`compile` method.
+while passing them other expressions and constants as arguments, and finally calling the
+:meth:`~aerospike_helpers.expressions.resources._BaseExpr.compile` method.
 
 Example::
 
@@ -168,6 +169,7 @@ aerospike\_helpers\.expressions\.base module
     :members:
     :special-members:
     :show-inheritance:
+    :private-members: _Key
 
 aerospike\_helpers\.expressions\.list module
 --------------------------------------------
@@ -215,9 +217,10 @@ aerospike\_helpers\.expressions\.bitwise_operators module
 aerospike\_helpers\.expressions\.resources module
 --------------------------------------------------
 
-.. automodule:: aerospike_helpers.expressions.resources
+.. autoclass:: aerospike_helpers.expressions.resources.ResultType
+  :members:
+  :undoc-members:
 
-    .. autoclass:: ResultType
-      :members:
-      :undoc-members:
-      :member-order: bysource
+.. autoclass:: aerospike_helpers.expressions.resources._BaseExpr
+
+.. automethod:: aerospike_helpers.expressions.resources._BaseExpr.compile

--- a/doc/aerospike_helpers.expressions.rst
+++ b/doc/aerospike_helpers.expressions.rst
@@ -217,7 +217,7 @@ aerospike\_helpers\.expressions\.bitwise_operators module
 aerospike\_helpers\.expressions\.resources module
 --------------------------------------------------
 
-.. autoattribute:: aerospike_helpers.expressions.resources.TypeExpression
+.. autodata:: aerospike_helpers.expressions.resources.TypeExpression
 
 .. autoclass:: aerospike_helpers.expressions.resources.ResultType
   :members:

--- a/doc/aerospike_helpers.expressions.rst
+++ b/doc/aerospike_helpers.expressions.rst
@@ -217,6 +217,8 @@ aerospike\_helpers\.expressions\.bitwise_operators module
 aerospike\_helpers\.expressions\.resources module
 --------------------------------------------------
 
+.. autoattribute:: aerospike_helpers.expressions.resources.TypeExpression
+
 .. autoclass:: aerospike_helpers.expressions.resources.ResultType
   :members:
   :undoc-members:

--- a/doc/client.rst
+++ b/doc/client.rst
@@ -77,7 +77,7 @@ Connection
 
         Tests the connections between the client and the nodes of the cluster.
         If the result is ``False``, the client will require another call to
-        :meth:`~aerospike.connect`.
+        :meth:`~aerospike.Client.connect`.
 
         :rtype: :class:`bool`
 
@@ -264,7 +264,7 @@ Record Commands
     .. method:: remove_bin(key, list[, meta: dict[, policy: dict]])
 
         Remove a list of bins from a record with a given *key*. Equivalent to \
-        setting those bins to :meth:`aerospike.null` with a :meth:`~aerospike.put`.
+        setting those bins to :meth:`aerospike.null` with a :meth:`~aerospike.Client.put`.
 
         .. include:: ./deprecate_meta_ttl.rst
 
@@ -313,7 +313,7 @@ Batched Commands
         This method allows different sub-commands for each key in the batch.
         The resulting status and operated bins are set in ``batch_records.results`` and ``batch_records.record``.
 
-        :param BatchRecords batch_records: A :class:`BatchRecords` object used to specify the operations to carry out.
+        :param BatchRecords batch_records: A :class:`~aerospike_helpers.batch.records.BatchRecords` object used to specify the operations to carry out.
         :param dict policy_batch: aerospike batch policy :ref:`aerospike_batch_policies`.
 
         :return: A reference to the batch_records argument of type :class:`BatchRecords <aerospike_helpers.batch.records>`.
@@ -527,7 +527,7 @@ Transactions
 .. class:: Client
     :noindex:
 
-    .. method:: commit(transaction: aerospike.Transaction) -> int:
+    .. method:: commit(transaction: aerospike.Transaction) -> int
 
         Attempt to commit the given transaction. First, the expected record versions are
         sent to the server nodes for verification. If all nodes return success, the transaction is
@@ -539,7 +539,7 @@ Transactions
         :type transaction: :py:class:`aerospike.Transaction`
         :return: The status of the commit. One of :ref:`mrt_commit_status_constants`.
 
-    .. method:: abort(transaction: aerospike.Transaction) -> int:
+    .. method:: abort(transaction: aerospike.Transaction) -> int
 
         Abort and rollback the given transaction.
 
@@ -757,7 +757,7 @@ Info Operations
 
         .. note:: Use :meth:`get_node_names` as an easy way to get host IP to node name mappings.
 
-    .. method:: info_all(command[, policy: dict]]) -> {}
+    .. method:: info_all(command[, policy: dict]]) -> dict
 
         Send an info command to all nodes in the cluster to which the client is connected.
 
@@ -795,7 +795,7 @@ Info Operations
 
         :param str data_center: The data center to apply the filter to.
         :param str namespace: The namespace to apply the filter to.
-        :param AerospikeExpression expression_filter: The filter to set. See expressions at :py:mod:`aerospike_helpers`.
+        :param expression_filter: The compiled expression filter to set. See expressions at :py:mod:`aerospike_helpers`.
         :param dict policy: optional :ref:`aerospike_info_policies`.
         :raises: a subclass of :exc:`~aerospike.exception.AerospikeError`.
 
@@ -811,7 +811,7 @@ Info Operations
 
         See :ref:`aerospike_operation_helpers.expressions` for more details on expressions.
 
-        :param AerospikeExpression expression: the compiled expression.
+        :param expression: the compiled expression. See expressions at :py:mod:`aerospike_helpers`.
         :raises: a subclass of :exc:`~aerospike.exception.AerospikeError`.
 
         .. include:: examples/get_expression_base64.py
@@ -838,12 +838,13 @@ Info Operations
 
         :param str namespace: The namespace to truncate.
         :param str set: The set to truncate. Pass in :py:obj:`None` to truncate a namespace instead.
-        :param long nanos:  A cutoff threshold where records last updated before the threshold will be removed.
+        :param int nanos:  A cutoff threshold where records last updated before the threshold will be removed.
             Units are in nanoseconds since the UNIX epoch ``(1970-01-01)``.
             A value of ``0`` indicates that all records in the set should be truncated regardless of update time.
             The value must not be in the future.
         :param dict policy: See :ref:`aerospike_info_policies`.
-        :rtype: Status indicating the success of the operation.
+        :return: Status indicating the success of the operation.
+        :rtype: int
         :raises: a subclass of :exc:`~aerospike.exception.AerospikeError`.
 
         .. note:: Requires Aerospike server version >= 3.12
@@ -870,7 +871,7 @@ Index Operations
         :param int index_datatype: the type of the value being indexed. See :ref:`aerospike_index_datatypes`.
         :param str name: the name of the index.
         :param dict policy: a dictionary defined by :ref:`aerospike_info_policies`. Defaults to :py:obj:`None`.
-        :param optional dict ctx: an optional :class:`list` of contexts produced by :mod:`aerospike_helpers.cdt_ctx` methods. Defaults to :py:obj:`None`.
+        :param dict | None ctx: an optional :class:`list` of contexts produced by :mod:`aerospike_helpers.cdt_ctx` methods. Defaults to :py:obj:`None`.
         :raises: a subclass of :exc:`~aerospike.exception.AerospikeError`.
 
     .. method:: index_list_create(ns, set, bin, index_datatype, name, policy: dict = None, ctx: list = None)
@@ -883,7 +884,7 @@ Index Operations
         :param int index_datatype: the type of the values being indexed. See :ref:`aerospike_index_datatypes`.
         :param str name: the name of the index.
         :param dict policy: optional :ref:`aerospike_info_policies`.
-        :param optional dict ctx: an optional :class:`list` of contexts produced by :mod:`aerospike_helpers.cdt_ctx` methods. Defaults to :py:obj:`None`.
+        :param dict | None ctx: an optional :class:`list` of contexts produced by :mod:`aerospike_helpers.cdt_ctx` methods. Defaults to :py:obj:`None`.
         :raises: a subclass of :exc:`~aerospike.exception.AerospikeError`.
 
     .. method:: index_map_keys_create(ns, set, bin, index_datatype, name, policy: dict = None, ctx: list = None)
@@ -896,7 +897,7 @@ Index Operations
         :param int index_datatype: the type of the values being indexed. See :ref:`aerospike_index_datatypes`.
         :param str name: the name of the index.
         :param dict policy: optional :ref:`aerospike_info_policies`.
-        :param optional dict ctx: an optional :class:`list` of contexts produced by :mod:`aerospike_helpers.cdt_ctx` methods. Defaults to :py:obj:`None`.
+        :param dict | None ctx: an optional :class:`list` of contexts produced by :mod:`aerospike_helpers.cdt_ctx` methods. Defaults to :py:obj:`None`.
         :raises: a subclass of :exc:`~aerospike.exception.AerospikeError`.
 
         .. note:: Requires server version >= 3.8.0
@@ -911,7 +912,7 @@ Index Operations
         :param int index_datatype: the type of the values being indexed. See :ref:`aerospike_index_datatypes`.
         :param str name: the name of the index.
         :param dict policy: optional :ref:`aerospike_info_policies`.
-        :param optional dict ctx: an optional :class:`list` of contexts produced by :mod:`aerospike_helpers.cdt_ctx` methods. Defaults to :py:obj:`None`.
+        :param dict | None ctx: an optional :class:`list` of contexts produced by :mod:`aerospike_helpers.cdt_ctx` methods. Defaults to :py:obj:`None`.
         :raises: a subclass of :exc:`~aerospike.exception.AerospikeError`.
 
         .. note:: Requires server version >= 3.8.0
@@ -1165,7 +1166,7 @@ user\'s roles. Users are assigned roles, which are collections of \
 
         :raises: one of the :exc:`~aerospike.exception.AdminError` subclasses.
 
-    .. method:: admin_get_role(role[, policy: dict]) -> {}
+    .. method:: admin_get_role(role[, policy: dict]) -> dict
 
         Get a :class:`dict` of privileges, whitelist, and quotas associated with a role.
 
@@ -1176,7 +1177,7 @@ user\'s roles. Users are assigned roles, which are collections of \
 
         :raises: one of the :exc:`~aerospike.exception.AdminError` subclasses.
 
-    .. method:: admin_get_roles([policy: dict]) -> {}
+    .. method:: admin_get_roles([policy: dict]) -> dict
 
         Get the names of all roles and their attributes.
 
@@ -1186,7 +1187,7 @@ user\'s roles. Users are assigned roles, which are collections of \
 
         :raises: one of the :exc:`~aerospike.exception.AdminError` subclasses.
 
-    .. method:: admin_query_role(role[, policy: dict]) -> []
+    .. method:: admin_query_role(role[, policy: dict]) -> list
 
         Get the :class:`list` of privileges associated with a role.
 
@@ -1197,7 +1198,7 @@ user\'s roles. Users are assigned roles, which are collections of \
 
         :raises: one of the :exc:`~aerospike.exception.AdminError` subclasses.
 
-    .. method:: admin_query_roles([policy: dict]) -> {}
+    .. method:: admin_query_roles([policy: dict]) -> dict
 
         Get all named roles and their privileges.
 
@@ -1365,35 +1366,35 @@ User Dictionary
 
 The user dictionary has the following key-value pairs:
 
-    * ``"read_info"`` (:class:`list[int]`): list of read statistics.
+    * ``"read_info"`` (:class:`list`): list of read statistics.
       List may be :py:obj:`None`. Current statistics by offset are:
 
-       * 0: read quota in records per second
+       * 0: read quota in records per second (:class:`int`)
 
-       * 1: single record read command rate (TPS)
+       * 1: single record read command rate (TPS) (:class:`int`)
 
-       * 2: read scan/query record per second rate (RPS)
+       * 2: read scan/query record per second rate (RPS) (:class:`int`)
 
-       * 3: number of limitless read scans/queries
+       * 3: number of limitless read scans/queries (:class:`int`)
 
     Future server releases may add additional statistics.
 
-    * ``"write_info"`` (:class:`list[int]`): list of write statistics.
+    * ``"write_info"`` (:class:`list`): list of write statistics.
       List may be :py:obj:`None`. Current statistics by offset are:
 
-       * 0: write quota in records per second
+       * 0: write quota in records per second (:class:`int`)
 
-       * 1: single record write command rate (TPS)
+       * 1: single record write command rate (TPS) (:class:`int`)
 
-       * 2: write scan/query record per second rate (RPS)
+       * 2: write scan/query record per second rate (RPS) (:class:`int`)
 
-       * 3: number of limitless write scans/queries
+       * 3: number of limitless write scans/queries (:class:`int`)
 
     Future server releases may add additional statistics.
 
     * ``"conns_in_use"`` (:class:`int`): number of currently open connections.
 
-    * ``"roles"`` (:class:`list[str]`): list of assigned role names.
+    * ``"roles"`` (:class:`list`): list of assigned role names. Each role name is a :class:`str`.
 
 Tuples
 ======
@@ -1754,9 +1755,9 @@ Read Policies
             |
             | Default: :data:`aerospike.POLICY_KEY_DIGEST`
         * **read_mode_ap**
-            | One of the :ref:`POLICY_READ_MODE_AP` values such as :data:`aerospike.AS_POLICY_READ_MODE_AP_ONE`
+            | One of the :ref:`POLICY_READ_MODE_AP` values such as :data:`aerospike.POLICY_READ_MODE_AP_ONE`
             |
-            | Default: :data:`aerospike.AS_POLICY_READ_MODE_AP_ONE`
+            | Default: :data:`aerospike.POLICY_READ_MODE_AP_ONE`
 
             .. versionadded:: 3.7.0
 
@@ -1852,9 +1853,9 @@ Operate Policies
             |
             | Default: :data:`aerospike.POLICY_COMMIT_LEVEL_ALL`
         * **read_mode_ap**
-            | One of the :ref:`POLICY_READ_MODE_AP` values such as :data:`aerospike.AS_POLICY_READ_MODE_AP_ONE`
+            | One of the :ref:`POLICY_READ_MODE_AP` values such as :data:`aerospike.POLICY_READ_MODE_AP_ONE`
             |
-            | Default: :data:`aerospike.AS_POLICY_READ_MODE_AP_ONE`
+            | Default: :data:`aerospike.POLICY_READ_MODE_AP_ONE`
 
             .. versionadded:: 3.7.0
 
@@ -1971,9 +1972,9 @@ Batch Policies
         :columns: 1
 
         * **read_mode_ap**
-            | One of the :ref:`POLICY_READ_MODE_AP` values such as :data:`aerospike.AS_POLICY_READ_MODE_AP_ONE`
+            | One of the :ref:`POLICY_READ_MODE_AP` values such as :data:`aerospike.POLICY_READ_MODE_AP_ONE`
             |
-            | Default: :data:`aerospike.AS_POLICY_READ_MODE_AP_ONE`
+            | Default: :data:`aerospike.POLICY_READ_MODE_AP_ONE`
 
             .. versionadded:: 3.7.0
 
@@ -2054,7 +2055,7 @@ Batch Write Policies
 
 .. object:: policy
 
-    A :class:`dict` of optional batch write policies, which are applicable to :meth:`~aerospike.batch_write`, :meth:`~aerospike.batch_operate` and :class:`Write <aerospike_helpers.batch.records>`.
+    A :class:`dict` of optional batch write policies, which are applicable to :meth:`~aerospike.Client.batch_write`, :meth:`~aerospike.Client.batch_operate` and :class:`Write <aerospike_helpers.batch.records>`.
 
     .. hlist::
         :columns: 1
@@ -2109,7 +2110,7 @@ Batch Apply Policies
 
 .. object:: policy
 
-    A :class:`dict` of optional batch apply policies, which are applicable to :meth:`~aerospike.batch_apply`, and :class:`Apply <aerospike_helpers.batch.records>`.
+    A :class:`dict` of optional batch apply policies, which are applicable to :meth:`~aerospike.Client.batch_apply`, and :class:`Apply <aerospike_helpers.batch.records>`.
 
     .. hlist::
         :columns: 1
@@ -2148,7 +2149,7 @@ Batch Remove Policies
 
 .. object:: policy
 
-    A :class:`dict` of optional batch remove policies, which are applicable to :meth:`~aerospike.batch_remove`, and :class:`Remove <aerospike_helpers.batch.records>`.
+    A :class:`dict` of optional batch remove policies, which are applicable to :meth:`~aerospike.Client.batch_remove`, and :class:`Remove <aerospike_helpers.batch.records>`.
 
     .. hlist::
         :columns: 1
@@ -2191,9 +2192,9 @@ Batch Read Policies
         :columns: 1
 
         * **read_mode_ap**
-            | One of the :ref:`POLICY_READ_MODE_AP` values such as :data:`aerospike.AS_POLICY_READ_MODE_AP_ONE`
+            | One of the :ref:`POLICY_READ_MODE_AP` values such as :data:`aerospike.POLICY_READ_MODE_AP_ONE`
             |
-            | Default: :data:`aerospike.AS_POLICY_READ_MODE_AP_ONE`
+            | Default: :data:`aerospike.POLICY_READ_MODE_AP_ONE`
         * **read_mode_sc**
             | One of the :ref:`POLICY_READ_MODE_SC` values such as :data:`aerospike.POLICY_READ_MODE_SC_SESSION`
             |
@@ -2229,7 +2230,7 @@ Info Policies
 
 .. object:: policy
 
-    A :class:`dict` of optional info policies, which are applicable to :meth:`~aerospike.info_all`, :meth:`~aerospike.info_single_node`, :meth:`~aerospike.info_random_node` and index operations.
+    A :class:`dict` of optional info policies, which are applicable to :meth:`~aerospike.Client.info_all`, :meth:`~aerospike.Client.info_single_node`, :meth:`~aerospike.Client.info_random_node` and index operations.
 
     .. hlist::
         :columns: 1

--- a/doc/client.rst
+++ b/doc/client.rst
@@ -795,7 +795,7 @@ Info Operations
 
         :param str data_center: The data center to apply the filter to.
         :param str namespace: The namespace to apply the filter to.
-        :param expression_filter: The compiled expression filter to set. See expressions at :py:mod:`aerospike_helpers`.
+        :param TypeExpression expression_filter: The compiled expression filter to set. See expressions at :py:mod:`aerospike_helpers`.
         :param dict policy: optional :ref:`aerospike_info_policies`.
         :raises: a subclass of :exc:`~aerospike.exception.AerospikeError`.
 
@@ -811,7 +811,7 @@ Info Operations
 
         See :ref:`aerospike_operation_helpers.expressions` for more details on expressions.
 
-        :param expression: the compiled expression. See expressions at :py:mod:`aerospike_helpers`.
+        :param TypeExpression expression: the compiled expression. See expressions at :py:mod:`aerospike_helpers`.
         :raises: a subclass of :exc:`~aerospike.exception.AerospikeError`.
 
         .. include:: examples/get_expression_base64.py

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -136,7 +136,7 @@ autodoc_type_aliases = {
 }
 nitpicky = True
 nitpick_ignore_regex = {
-    ("*", "Type*")
+    ("py:class", "Type*")
 }
 
 # -- Options for HTML output ---------------------------------------------------

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -136,7 +136,7 @@ autodoc_type_aliases = {
 }
 nitpicky = True
 nitpick_ignore_regex = {
-    ("py:class", "Type*")
+    ("py:class", "Type.*")
 }
 
 # -- Options for HTML output ---------------------------------------------------

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -134,6 +134,7 @@ autodoc_type_aliases = {
     "TypeFixedEle": "TypeFixedEle",
     "TypeFixed": "TypeFixed",
 }
+nitpicky = True
 
 # -- Options for HTML output ---------------------------------------------------
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -135,6 +135,9 @@ autodoc_type_aliases = {
     "TypeFixed": "TypeFixed",
 }
 nitpicky = True
+nitpick_ignore_regex = {
+    ("*", "Type*")
+}
 
 # -- Options for HTML output ---------------------------------------------------
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -120,7 +120,7 @@ autodoc_type_aliases = {
     "TypeIndex": "TypeIndex",
     "TypeChild": "TypeChild",
     "TypeCompiledOp": "TypeCompiledOp",
-    "TypeExpression": "TypeExpression",
+    "TypeExpression": "aerospike_helpers.expressions.resources.TypeExpression",
     "TypeGeo": "TypeGeo",
     "TypeKey": "TypeKey",
     "TypeKeyList": "TypeKeyList",

--- a/doc/config_provider.rst
+++ b/doc/config_provider.rst
@@ -22,7 +22,7 @@ Methods
 
     :param interval: Interval in milliseconds between dynamic configuration check for file modifications.
         The value must be greater than or equal to the tend interval. Defaults to ``5000``.
-    :type interval: int, optional
+    :type interval: int | None
 
     .. py:attribute:: path
 

--- a/doc/data_mapping.rst
+++ b/doc/data_mapping.rst
@@ -52,7 +52,7 @@ The following table shows which Python types map directly to Aerospike server ty
   :class:`int`                             `integer`_
   :class:`bool`                            depends on send_bool_as
   :class:`str`                             `string`_
-  :class:`unicode`                         `string`_
+  :class:`str`                             `string`_
   :class:`float`                           `double`_
   :class:`dict`                            `map`_
   :class:`aerospike.KeyOrderedDict`        `key ordered map`_

--- a/doc/exception.rst
+++ b/doc/exception.rst
@@ -61,7 +61,7 @@ Base Class
     ``i`` is the index of the attribute in the order they appear above. \
     For example, run ``exc.args[4]`` to get the ``in_doubt`` flag.
 
-    Inherits from :py:exc:`exceptions.Exception`.
+    Inherits from :py:exc:`Exception`.
 
 Client Errors
 -------------

--- a/doc/geojson.rst
+++ b/doc/geojson.rst
@@ -93,7 +93,7 @@ Methods
 
         :param dict geo_data: a :class:`dict` representing the geospatial data.
 
-    .. method:: unwrap() -> dict of geospatial data
+    .. method:: unwrap() -> dict
 
         Gets the geospatial data contained in the :class:`~aerospike.GeoJSON` class.
 
@@ -105,7 +105,7 @@ Methods
 
         :param str raw_geo: a GeoJSON string representation.
 
-    .. method:: dumps() -> a GeoJSON string
+    .. method:: dumps() -> str
 
         Gets the geospatial data contained in the :class:`~aerospike.GeoJSON` class as a GeoJSON string.
 

--- a/doc/predicates.rst
+++ b/doc/predicates.rst
@@ -65,7 +65,7 @@ GeoJSON Predicates
 
     Predicate for finding any point in bin which is within the given shape.
     Requires a geo2dsphere index
-    (:meth:`~aerospike.index_geo2dsphere_create`) over a *bin*
+    (:meth:`~aerospike.Client.index_geo2dsphere_create`) over a *bin*
     containing :class:`~aerospike.GeoJSON` point data.
 
     :param Optional[str] bin: the bin name.
@@ -114,7 +114,7 @@ GeoJSON Predicates
     Predicate helper builds an AeroCircle GeoJSON shape, and returns a
     'within GeoJSON region' predicate.
     Requires a geo2dsphere index
-    (:meth:`~aerospike.index_geo2dsphere_create`) over a *bin*
+    (:meth:`~aerospike.Client.index_geo2dsphere_create`) over a *bin*
     containing :class:`~aerospike.GeoJSON` point data.
 
     :param Optional[str] bin: the bin name.
@@ -153,7 +153,7 @@ GeoJSON Predicates
 
     Predicate for finding any regions in the bin which contain the given point.
     Requires a geo2dsphere index
-    (:meth:`~aerospike.index_geo2dsphere_create`) over a *bin*
+    (:meth:`~aerospike.Client.index_geo2dsphere_create`) over a *bin*
     containing :class:`~aerospike.GeoJSON` point data.
 
     :param Optional[str] bin: the bin name.
@@ -199,7 +199,7 @@ GeoJSON Predicates
     Predicate helper builds a GeoJSON point, and returns a
     'contains GeoJSON point' predicate.
     Requires a geo2dsphere index
-    (:meth:`~aerospike.index_geo2dsphere_create`) over a *bin*
+    (:meth:`~aerospike.Client.index_geo2dsphere_create`) over a *bin*
     containing :class:`~aerospike.GeoJSON` point data.
 
     :param Optional[str] bin: the bin name.

--- a/doc/query.rst
+++ b/doc/query.rst
@@ -43,7 +43,7 @@ Background Queries
 
 If a list of write operations is added to the query with :meth:`~aerospike.Query.add_ops`, \
 they will be applied to each record processed by the query. \
-See available write operations at :mod:`aerospike_helpers.operations`.
+See available write operations at :ref:`aerospike_operation_helpers.operations`.
 
 
 Foreground Queries
@@ -151,10 +151,11 @@ Assume this boilerplate code is run before all examples below:
 
         You can only assign at most one predicate to the query.
 
-        :param aerospike_helpers.expressions.resources.TypeExpression | str expr:
+        :param expr:
             Compiled aerospike expressions produced from :ref:`aerospike_operation_helpers.expressions`.
             Alternatively, you can pass in a base64 encoded string of an expression returned from asinfo when printing
             a list of secondary indexes based on expressions in the server.
+
         :param tuple predicate: the :class:`tuple` produced from :mod:`aerospike.predicates`
 
     .. method:: where_with_index_name(index_name, predicate)
@@ -165,7 +166,7 @@ Assume this boilerplate code is run before all examples below:
 
         You can only assign at most one predicate to the query.
 
-        :param index_name str: The name of the index.
+        :param str index_name: The name of the index.
         :param tuple predicate: the :class:`tuple` produced from :mod:`aerospike.predicates`
 
     .. method:: results([,policy [, options]]) -> list of (key, meta, bins)
@@ -213,7 +214,7 @@ Assume this boilerplate code is run before all examples below:
         The first is a :class:`int` representing partition id, the second is the same :ref:`aerospike_record_tuple`
         as a normal callback.
 
-        :param callable callback: the function to invoke for each record.
+        :param typing.Callable callback: the function to invoke for each record.
         :param dict policy: optional :ref:`aerospike_query_policies`.
         :param dict options: optional :ref:`aerospike_query_options`.
 

--- a/doc/query.rst
+++ b/doc/query.rst
@@ -151,7 +151,7 @@ Assume this boilerplate code is run before all examples below:
 
         You can only assign at most one predicate to the query.
 
-        :param expr:
+        :param TypeExpression | str expr:
             Compiled aerospike expressions produced from :ref:`aerospike_operation_helpers.expressions`.
             Alternatively, you can pass in a base64 encoded string of an expression returned from asinfo when printing
             a list of secondary indexes based on expressions in the server.

--- a/doc/scan.rst
+++ b/doc/scan.rst
@@ -18,8 +18,8 @@ The Scan object is used to return all the records in a specified set (which \
 can be omitted or :py:obj:`None`). A Scan with a :py:obj:`None` set returns all the \
 records in the namespace.
 
-The scan is invoked using :meth:`foreach`, :meth:`results`, or :meth:`execute_background`. The \
-bins returned can be filtered using :meth:`select`.
+The scan is invoked using :meth:`~aerospike.Scan.foreach`, :meth:`~aerospike.Scan.results`, or
+:meth:`~aerospike.Scan.execute_background`. The bins returned can be filtered using :meth:`~aerospike.Scan.select`.
 
 .. seealso::
     `Manage queries <https://aerospike.com/docs/database/manage/cluster/queries/>`_.
@@ -29,7 +29,9 @@ Fields
 
 .. class:: Scan
 
-    ttl (:class:`int`)
+    .. py:attribute:: ttl
+        :type: int
+
         The time-to-live (expiration) of the record in seconds. Note that ttl
         is only used on background scan writes.
 
@@ -182,7 +184,7 @@ Methods
         Invoke the *callback* function for each of the records streaming back \
         from the scan.
 
-        :param callable callback: the function to invoke for each record.
+        :param typing.Callable callback: the function to invoke for each record.
         :param dict policy: optional :ref:`aerospike_scan_policies`.
         :param dict options: the :ref:`aerospike_scan_options` that will apply to the scan.
         :param str nodename: optional Node ID of node used to limit the scan to a single node.

--- a/doc/transaction.rst
+++ b/doc/transaction.rst
@@ -17,9 +17,9 @@ Methods
     For both parameters, an unsigned 32-bit integer must be passed and the minimum value should be 16.
 
     :param reads_capacity: expected number of record reads in the transaction. Defaults to ``128``.
-    :type reads_capacity: int, optional
+    :type reads_capacity: typing.Optional[int]
     :param writes_capacity: expected number of record writes in the transaction. Defaults to ``128``.
-    :type writes_capacity: int, optional
+    :type writes_capacity: typing.Optional[int]
 
     .. py:attribute:: id
 

--- a/doc/transaction.rst
+++ b/doc/transaction.rst
@@ -17,9 +17,9 @@ Methods
     For both parameters, an unsigned 32-bit integer must be passed and the minimum value should be 16.
 
     :param reads_capacity: expected number of record reads in the transaction. Defaults to ``128``.
-    :type reads_capacity: typing.Optional[int]
+    :type reads_capacity: int | None
     :param writes_capacity: expected number of record writes in the transaction. Defaults to ``128``.
-    :type writes_capacity: typing.Optional[int]
+    :type writes_capacity: int | None
 
     .. py:attribute:: id
 


### PR DESCRIPTION
## Manual testing

- [_BaseExpr and _BaseExpr.compile() can now be referenced](https://aerospike-python-client--1024.org.readthedocs.build/en/1024/aerospike_helpers.expressions.html#aerospike_helpers.expressions.resources._BaseExpr.compile)
- [Example cross reference to `_BaseExpr` that now works.](https://aerospike-python-client--1024.org.readthedocs.build/en/1024/aerospike_helpers.expressions.html#aerospike_helpers.expressions.base.Cond)
- [Reference to compiled expression type alias now works](https://aerospike-python-client--1024.org.readthedocs.build/en/1024/aerospike_helpers.cdt_ctx.html#aerospike_helpers.cdt_ctx.cdt_ctx_and_filter). Also in `aerospike` module [here](https://aerospike-python-client--1024.org.readthedocs.build/en/1024/client.html#aerospike.Client.set_xdr_filter).

## Extra notes

- [x] Add type aliases to ignore list for now. There is another PR #991 that fixes the warnings for those type aliases, but it leverages a new extension called `sphinx-autodoc-typehints` which currently causes some regressions in how the docs are rendered.

## Known issues
- Somehow `sphinx-autodoc-typehints` isn't setting `TYPE_CHECKING` to true, so if importing `Any` is done under a `TYPE_CHECKING` if statement block, there's a `NameError` when using `Any`.