### PR TITLE
[CLIENT-4670] Docs: Add missing documentation for client.index_set_create()

### DIFF
--- a/doc/client.rst
+++ b/doc/client.rst
@@ -944,6 +944,17 @@ Index Operations
         :param dict policy: optional :ref:`aerospike_info_policies`.
         :raises: a subclass of :exc:`~aerospike.exception.AerospikeError`.
 
+    .. method:: index_set_create(ns, set, name, policy: dict = None)
+
+        Create a set index.
+
+        :param str ns: the namespace in the aerospike cluster.
+        :param str set: the set name.
+        :param str name: the name of the index.
+        :param dict | None policy: optional :ref:`aerospike_info_policies`.
+
+        .. note:: Requires server version >= 18.2.0
+
     .. method:: index_remove(ns: str, name: str[, policy: dict])
 
         Remove the index with *name* from the namespace.

--- a/test/new_tests/test_set_index.py
+++ b/test/new_tests/test_set_index.py
@@ -49,7 +49,7 @@ class TestSetIndex:
     )
     def test_create_set_index(self, client_as_sindex_admin_user, expect_earlier_than_server_version_to_fail):
         with self.expected_context_for_pos_tests:
-            client_as_sindex_admin_user.index_set_create("test", "demo", INDEX_NAME)
+            client_as_sindex_admin_user.index_set_create(ns="test", set="demo", name=INDEX_NAME, policy=None)
 
     def test_create_set_index_with_invalid_args(self):
         with pytest.raises(TypeError):


### PR DESCRIPTION
## Extra changes
- Test kwargs for client.index_set_create()

## Manual testing
- Docs link: https://aerospike-python-client--1031.org.readthedocs.build/en/1031/client.html#aerospike.Client.index_set_create