### PR TITLE
[CLIENT-4666] CI/CD: Fast forward master branch to stage when the JFrog release bundle is promoted to production (published to PyPI)

### DIFF
--- a/.github/workflows/stage-to-master.yml
+++ b/.github/workflows/stage-to-master.yml
@@ -1,5 +1,6 @@
 name: Stage to master
 on:
+  # TODO: cannot be run manually, should be triggered by jfrog
   workflow_dispatch:
 
 jobs:
@@ -8,76 +9,4 @@ jobs:
     with:
       ref_to_merge: origin/${{ vars.STAGE_BRANCH_NAME }}
       base_branch: ${{ vars.MASTER_BRANCH_NAME }}
-    secrets: inherit
-
-  promote-rc-build-to-release:
-    needs: ff-master-to-stage
-    uses: ./.github/workflows/bump-version.yml
-    with:
-      change: promote-rc-build-to-release
-      ref: ${{ vars.MASTER_BRANCH_NAME }}
-    secrets: inherit
-
-  build-artifacts:
-    needs: promote-rc-build-to-release
-    uses: ./.github/workflows/build-artifacts.yml
-    with:
-      sha-to-build-and-test: ${{ needs.promote-rc-build-to-release.outputs.bump_sha }}
-    secrets: inherit
-
-  upload-to-jfrog:
-    name: Upload artifacts to JFrog
-    needs: [
-      build-artifacts,
-      promote-rc-build-to-release
-    ]
-    uses: ./.github/workflows/upload-to-jfrog.yml
-    with:
-      version: ${{ needs.promote-rc-build-to-release.outputs.new_version }}
-    secrets: inherit
-
-  publish-to-pypi:
-    runs-on: ubuntu-22.04
-    needs: build-artifacts
-    steps:
-    - name: Harden the runner (Audit all outbound calls)
-      uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
-      with:
-        egress-policy: audit
-
-    - name: Download and store all artifacts to single folder
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-      with:
-        path: artifacts
-        merge-multiple: true
-
-    # TODO: fix
-    - name: Publish package distributions to PyPI
-      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
-      with:
-        packages-dir: artifacts/
-        password: ${{ secrets.PYPI_API_TOKEN }}
-
-  # See reason for deleting artifacts in dev-workflow-p2.yml
-  delete-artifacts:
-    needs: [
-      upload-to-jfrog,
-      publish-to-pypi
-    ]
-    uses: ./.github/workflows/delete-artifacts.yml
-
-  fast-forward-stage-to-master:
-    needs: build-artifacts
-    uses: ./.github/workflows/fast-forward-merge.yml
-    with:
-      ref_to_merge: origin/${{ vars.MASTER_BRANCH_NAME }}
-      base_branch: ${{ vars.STAGE_BRANCH_NAME }}
-    secrets: inherit
-
-  fast-forward-dev-to-master:
-    needs: build-artifacts
-    uses: ./.github/workflows/fast-forward-merge.yml
-    with:
-      ref_to_merge: origin/${{ vars.MASTER_BRANCH_NAME }}
-      base_branch: ${{ vars.DEV_BRANCH_NAME }}
     secrets: inherit


### PR DESCRIPTION
## TODO
- [ ] Once approved and merged, the referenced secrets should be removed from the repo and invalidated (assuming this secret is only used for this pipeline)