### PR TITLE
[CLIENT-4584] CI/CD: Push and pull custom manylinux images from JFrog instead of ghcr.io

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -3,6 +3,11 @@ run-name: 'Build wheels (python-tags=${{ inputs.python-tags }}, platform-tag=${{
 
 # Build wheels on all (or select) Python versions supported by the Python client for a specific platform
 
+permissions:
+  id-token: write
+  contents: read
+  statuses: write
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -268,7 +268,8 @@ jobs:
     - if: ${{ startsWith(inputs.platform-tag, 'manylinux') }}
       run: echo CIBW_MANYLINUX_AARCH64_IMAGE=${{ format(env.CUSTOM_IMAGE_NAME, 'aarch64', '3e814781f3025a4659eefdc2aa1dca593eb1d9e0d6c6e1d1f543d17429eb5bdb') }} >> $GITHUB_ENV
 
-    - name: Setup JFrog CLI
+    - if: ${{ startsWith(inputs.platform-tag, 'manylinux') }}
+      name: Setup JFrog CLI
       id: setup-jf
       uses: jfrog/setup-jfrog-cli@1641575d87647fb969c0545f0b6a76873e328b7c # v5.0.0
       env:
@@ -278,7 +279,8 @@ jobs:
         oidc-provider-name: ${{ vars.OIDC_PROVIDER_NAME }}
         oidc-audience: ${{ vars.OIDC_AUDIENCE }}
 
-    - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+    - if: ${{ startsWith(inputs.platform-tag, 'manylinux') }}
+      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
       with:
         registry: ${{ vars.JF_EXTERNAL_URL }}/${{ vars.JFROG_REPO_FOR_CUSTOM_MANYLINUX_IMAGES }}
         username: ${{ steps.setup-jf.outputs.oidc-user }}

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -272,7 +272,7 @@ jobs:
       id: setup-jf
       uses: jfrog/setup-jfrog-cli@1641575d87647fb969c0545f0b6a76873e328b7c # v5.0.0
       env:
-        JF_URL: https://artifact.aerospike.io
+        JF_URL: ${{ vars.JF_URL }}
       with:
         version: '2.92.0'
         oidc-provider-name: ${{ vars.OIDC_PROVIDER_NAME }}

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -263,10 +263,10 @@ jobs:
     # OpenSSL locked version for this git revision: 3.0.15
     # We lock the digest for security reasons.
     - if: ${{ startsWith(inputs.platform-tag, 'manylinux') }}
-      run: echo CIBW_MANYLINUX_X86_64_IMAGE=${{ format(env.CUSTOM_IMAGE_NAME, 'x86_64', 'c31153ffa4a797a2ead9cb35ad1c08a2ddfdd93de730414a65a73003e7b410fa') }} >> $GITHUB_ENV
+      run: echo CIBW_MANYLINUX_X86_64_IMAGE=${{ format(env.CUSTOM_IMAGE_NAME, 'x86_64', '8a93a781fb0f9ea675e7f9c1fe9f52ddf7e560de05a938023a15fb85e540da9e') }} >> $GITHUB_ENV
 
     - if: ${{ startsWith(inputs.platform-tag, 'manylinux') }}
-      run: echo CIBW_MANYLINUX_AARCH64_IMAGE=${{ format(env.CUSTOM_IMAGE_NAME, 'aarch64', '6c75a63f18d06e7cc739d825dd0df8b5fee4ce8433f893535f0ee248f34723ea') }} >> $GITHUB_ENV
+      run: echo CIBW_MANYLINUX_AARCH64_IMAGE=${{ format(env.CUSTOM_IMAGE_NAME, 'aarch64', 'bece22a95b868e176c30d1c52c1d5501ad9fcf29ccc2b9824993c5bec6e32d9d') }} >> $GITHUB_ENV
 
     - name: Setup JFrog CLI
       id: setup-jf

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -188,7 +188,7 @@ jobs:
     env:
       BUILD_IDENTIFIER: "${{ matrix.python-tag }}-${{ inputs.platform-tag }}"
       MACOS_OPENSSL_VERSION: 3
-      CUSTOM_IMAGE_NAME: ${{ vars.JF_INTERNAL_URL }}/${{ vars.JFROG_REPO_FOR_CUSTOM_MANYLINUX_IMAGES }}/manylinux_2_28_{0}@sha256:{1}
+      CUSTOM_IMAGE_NAME: ${{ vars.JF_EXTERNAL_URL }}/${{ vars.JFROG_REPO_FOR_CUSTOM_MANYLINUX_IMAGES }}/manylinux_2_28_{0}@sha256:{1}
     steps:
     - name: Harden the runner (Audit all outbound calls)
       uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
@@ -280,7 +280,7 @@ jobs:
 
     - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
       with:
-        registry: ${{ vars.JF_INTERNAL_URL }}
+        registry: ${{ vars.JF_EXTERNAL_URL }}/${{ vars.JFROG_REPO_FOR_CUSTOM_MANYLINUX_IMAGES }}
         username: ${{ steps.setup-jf.outputs.oidc-user }}
         password: ${{ steps.setup-jf.outputs.oidc-token }}
 

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -188,7 +188,7 @@ jobs:
     env:
       BUILD_IDENTIFIER: "${{ matrix.python-tag }}-${{ inputs.platform-tag }}"
       MACOS_OPENSSL_VERSION: 3
-      CUSTOM_IMAGE_NAME: aerospike.jfrog.io/${{ vars.JFROG_REPO_FOR_CUSTOM_MANYLINUX_IMAGES }}/manylinux_2_28_{0}@sha256:{1}
+      CUSTOM_IMAGE_NAME: ${{ vars.JF_INTERNAL_URL }}/${{ vars.JFROG_REPO_FOR_CUSTOM_MANYLINUX_IMAGES }}/manylinux_2_28_{0}@sha256:{1}
     steps:
     - name: Harden the runner (Audit all outbound calls)
       uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
@@ -272,7 +272,7 @@ jobs:
       id: setup-jf
       uses: jfrog/setup-jfrog-cli@1641575d87647fb969c0545f0b6a76873e328b7c # v5.0.0
       env:
-        JF_URL: ${{ vars.JF_URL }}
+        JF_URL: ${{ vars.JF_EXTERNAL_URL }}
       with:
         version: '2.92.0'
         oidc-provider-name: ${{ vars.OIDC_PROVIDER_NAME }}
@@ -280,7 +280,7 @@ jobs:
 
     - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
       with:
-        registry: aerospike.jfrog.io
+        registry: ${{ vars.JF_INTERNAL_URL }}
         username: ${{ steps.setup-jf.outputs.oidc-user }}
         password: ${{ steps.setup-jf.outputs.oidc-token }}
 

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -258,10 +258,10 @@ jobs:
     # OpenSSL locked version for this git revision: 3.0.15
     # We lock the digest for security reasons.
     - if: ${{ startsWith(inputs.platform-tag, 'manylinux') }}
-      run: echo CIBW_MANYLINUX_X86_64_IMAGE=${{ format(env.CUSTOM_IMAGE_NAME, 'x86_64', 'a3440f5f201789718cff4da8f0e1251f186016e36a1b2cfd739fc4d597f7b20c') }} >> $GITHUB_ENV
+      run: echo CIBW_MANYLINUX_X86_64_IMAGE=${{ format(env.CUSTOM_IMAGE_NAME, 'x86_64', 'c31153ffa4a797a2ead9cb35ad1c08a2ddfdd93de730414a65a73003e7b410fa') }} >> $GITHUB_ENV
 
     - if: ${{ startsWith(inputs.platform-tag, 'manylinux') }}
-      run: echo CIBW_MANYLINUX_AARCH64_IMAGE=${{ format(env.CUSTOM_IMAGE_NAME, 'aarch64', '22071eca37ed46821078ac1a6d4e9eccbbd96baa8d07e199ca4df4a299f9c120') }} >> $GITHUB_ENV
+      run: echo CIBW_MANYLINUX_AARCH64_IMAGE=${{ format(env.CUSTOM_IMAGE_NAME, 'aarch64', '6c75a63f18d06e7cc739d825dd0df8b5fee4ce8433f893535f0ee248f34723ea') }} >> $GITHUB_ENV
 
     - name: Setup JFrog CLI
       id: setup-jf

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -188,7 +188,7 @@ jobs:
     env:
       BUILD_IDENTIFIER: "${{ matrix.python-tag }}-${{ inputs.platform-tag }}"
       MACOS_OPENSSL_VERSION: 3
-      CUSTOM_IMAGE_NAME: artifact.aerospike.io/database-docker-dev-local/manylinux_2_28_{0}@sha256:{1}
+      CUSTOM_IMAGE_NAME: aerospike.jfrog.io/database-docker-dev-local/manylinux_2_28_{0}@sha256:{1}
     steps:
     - name: Harden the runner (Audit all outbound calls)
       uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -183,7 +183,7 @@ jobs:
     env:
       BUILD_IDENTIFIER: "${{ matrix.python-tag }}-${{ inputs.platform-tag }}"
       MACOS_OPENSSL_VERSION: 3
-      CUSTOM_IMAGE_NAME: ghcr.io/aerospike/manylinux_2_28_{0}@sha256:{1}
+      CUSTOM_IMAGE_NAME: aerospike.artifact.io/database-docker-prod-internal-local/manylinux_2_28_{0}@sha256:{1}
     steps:
     - name: Harden the runner (Audit all outbound calls)
       uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
@@ -263,12 +263,21 @@ jobs:
     - if: ${{ startsWith(inputs.platform-tag, 'manylinux') }}
       run: echo CIBW_MANYLINUX_AARCH64_IMAGE=${{ format(env.CUSTOM_IMAGE_NAME, 'aarch64', '22071eca37ed46821078ac1a6d4e9eccbbd96baa8d07e199ca4df4a299f9c120') }} >> $GITHUB_ENV
 
-    - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-      if: ${{ startsWith(inputs.platform-tag, 'manylinux') }}
+    - name: Setup JFrog CLI
+      id: setup-jf
+      uses: jfrog/setup-jfrog-cli@1641575d87647fb969c0545f0b6a76873e328b7c # v5.0.0
+      env:
+        JF_URL: https://artifact.aerospike.io
       with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+        version: '2.92.0'
+        oidc-provider-name: ${{ vars.OIDC_PROVIDER_NAME }}
+        oidc-audience: ${{ vars.OIDC_AUDIENCE }}
+
+    - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+      with:
+        registry: aerospike.jfrog.io
+        username: ${{ steps.setup-jf.outputs.oidc-user }}
+        password: ${{ steps.setup-jf.outputs.oidc-token }}
 
     # It is not documented in Github that openssl 3 / libyaml is installed in their macos images
     # so we install it here to be safe

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -188,7 +188,7 @@ jobs:
     env:
       BUILD_IDENTIFIER: "${{ matrix.python-tag }}-${{ inputs.platform-tag }}"
       MACOS_OPENSSL_VERSION: 3
-      CUSTOM_IMAGE_NAME: aerospike.artifact.io/database-docker-dev-local/manylinux_2_28_{0}@sha256:{1}
+      CUSTOM_IMAGE_NAME: artifact.aerospike.io/database-docker-dev-local/manylinux_2_28_{0}@sha256:{1}
     steps:
     - name: Harden the runner (Audit all outbound calls)
       uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -272,7 +272,7 @@ jobs:
       id: setup-jf
       uses: jfrog/setup-jfrog-cli@1641575d87647fb969c0545f0b6a76873e328b7c # v5.0.0
       env:
-        JF_URL: ${{ vars.JF_EXTERNAL_URL }}
+        JF_URL: https://${{ vars.JF_EXTERNAL_URL }}
       with:
         version: '2.92.0'
         oidc-provider-name: ${{ vars.OIDC_PROVIDER_NAME }}

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -183,7 +183,7 @@ jobs:
     env:
       BUILD_IDENTIFIER: "${{ matrix.python-tag }}-${{ inputs.platform-tag }}"
       MACOS_OPENSSL_VERSION: 3
-      CUSTOM_IMAGE_NAME: aerospike.artifact.io/database-docker-prod-internal-local/manylinux_2_28_{0}@sha256:{1}
+      CUSTOM_IMAGE_NAME: aerospike.artifact.io/database-docker-dev-local/manylinux_2_28_{0}@sha256:{1}
     steps:
     - name: Harden the runner (Audit all outbound calls)
       uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -263,10 +263,10 @@ jobs:
     # OpenSSL locked version for this git revision: 3.0.15
     # We lock the digest for security reasons.
     - if: ${{ startsWith(inputs.platform-tag, 'manylinux') }}
-      run: echo CIBW_MANYLINUX_X86_64_IMAGE=${{ format(env.CUSTOM_IMAGE_NAME, 'x86_64', '8a93a781fb0f9ea675e7f9c1fe9f52ddf7e560de05a938023a15fb85e540da9e') }} >> $GITHUB_ENV
+      run: echo CIBW_MANYLINUX_X86_64_IMAGE=${{ format(env.CUSTOM_IMAGE_NAME, 'x86_64', '6d32fb959e76ed2b2117b28d141b3a92aed81805fe23e357a9b247ea30b88ae5') }} >> $GITHUB_ENV
 
     - if: ${{ startsWith(inputs.platform-tag, 'manylinux') }}
-      run: echo CIBW_MANYLINUX_AARCH64_IMAGE=${{ format(env.CUSTOM_IMAGE_NAME, 'aarch64', 'bece22a95b868e176c30d1c52c1d5501ad9fcf29ccc2b9824993c5bec6e32d9d') }} >> $GITHUB_ENV
+      run: echo CIBW_MANYLINUX_AARCH64_IMAGE=${{ format(env.CUSTOM_IMAGE_NAME, 'aarch64', '3e814781f3025a4659eefdc2aa1dca593eb1d9e0d6c6e1d1f543d17429eb5bdb') }} >> $GITHUB_ENV
 
     - name: Setup JFrog CLI
       id: setup-jf

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -188,7 +188,7 @@ jobs:
     env:
       BUILD_IDENTIFIER: "${{ matrix.python-tag }}-${{ inputs.platform-tag }}"
       MACOS_OPENSSL_VERSION: 3
-      CUSTOM_IMAGE_NAME: aerospike.jfrog.io/database-docker-dev-local/manylinux_2_28_{0}@sha256:{1}
+      CUSTOM_IMAGE_NAME: aerospike.jfrog.io/${{ vars.JFROG_REPO_FOR_CUSTOM_MANYLINUX_IMAGES }}/manylinux_2_28_{0}@sha256:{1}
     steps:
     - name: Harden the runner (Audit all outbound calls)
       uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0

--- a/.github/workflows/update-manylinux-openssl-image.yml
+++ b/.github/workflows/update-manylinux-openssl-image.yml
@@ -44,7 +44,7 @@ jobs:
       id: setup-jf
       uses: jfrog/setup-jfrog-cli@1641575d87647fb969c0545f0b6a76873e328b7c # v5.0.0
       env:
-        JF_URL: ${{ vars.JF_EXTERNAL_URL }}
+        JF_URL: https://${{ vars.JF_EXTERNAL_URL }}
       with:
         version: '2.92.0'
         oidc-provider-name: ${{ vars.OIDC_PROVIDER_NAME }}

--- a/.github/workflows/update-manylinux-openssl-image.yml
+++ b/.github/workflows/update-manylinux-openssl-image.yml
@@ -53,7 +53,7 @@ jobs:
     - uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
       id: meta
       with:
-        images: ${{ vars.JF_INTERNAL_URL }}/${{ vars.JFROG_REPO_FOR_CUSTOM_MANYLINUX_IMAGES }}/${{ env.MANYLINUX_TAG }}_${{ matrix.arch-and-runner-os[0] }}
+        images: ${{ vars.JF_EXTERNAL_URL }}/${{ vars.JFROG_REPO_FOR_CUSTOM_MANYLINUX_IMAGES }}/${{ env.MANYLINUX_TAG }}_${{ matrix.arch-and-runner-os[0] }}
         # These images aren't used by customers, anyway.
         flavor: latest=false
 
@@ -97,7 +97,7 @@ jobs:
     - name: Log into internal JFrog registry
       uses: docker/login-action@v4
       with:
-        registry: ${{ vars.JF_INTERNAL_URL }}
+        registry: ${{ vars.JF_EXTERNAL_URL }}/${{ vars.JFROG_REPO_FOR_CUSTOM_MANYLINUX_IMAGES }}
         username: ${{ steps.setup-jf.outputs.oidc-user }}
         password: ${{ steps.setup-jf.outputs.oidc-token }}
 

--- a/.github/workflows/update-manylinux-openssl-image.yml
+++ b/.github/workflows/update-manylinux-openssl-image.yml
@@ -1,3 +1,7 @@
+permissions:
+  contents: read
+  id-token: write
+
 name: Build manylinux openssl image
 run-name: 'Build manylinux openssl image (openssl-version=${{ inputs.openssl-version }})'
 

--- a/.github/workflows/update-manylinux-openssl-image.yml
+++ b/.github/workflows/update-manylinux-openssl-image.yml
@@ -53,7 +53,7 @@ jobs:
     - uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
       id: meta
       with:
-        images: aerospike.jfrog.io/database-docker-prod-internal-local/${{ env.MANYLINUX_TAG }}_${{ matrix.arch-and-runner-os[0] }}
+        images: aerospike.jfrog.io/database-docker-dev-local/${{ env.MANYLINUX_TAG }}_${{ matrix.arch-and-runner-os[0] }}
         # These images aren't used by customers, anyway.
         flavor: latest=false
 

--- a/.github/workflows/update-manylinux-openssl-image.yml
+++ b/.github/workflows/update-manylinux-openssl-image.yml
@@ -36,16 +36,20 @@ jobs:
           .github/workflows
         path: aerospike-client-python
 
-    - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+    - name: Setup JFrog CLI
+      id: setup-jf
+      uses: jfrog/setup-jfrog-cli@1641575d87647fb969c0545f0b6a76873e328b7c # v5.0.0
+      env:
+        JF_URL: https://artifact.aerospike.io
       with:
-        registry: ${{ env.REGISTRY }}
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+        version: '2.92.0'
+        oidc-provider-name: ${{ vars.OIDC_PROVIDER_NAME }}
+        oidc-audience: ${{ vars.OIDC_AUDIENCE }}
 
     - uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
       id: meta
       with:
-        images: ${{ env.REGISTRY }}/aerospike/${{ env.MANYLINUX_TAG }}_${{ matrix.arch-and-runner-os[0] }}
+        images: ${{ env.MANYLINUX_TAG }}_${{ matrix.arch-and-runner-os[0] }}
         # These images aren't used by customers, anyway.
         flavor: latest=false
 
@@ -85,6 +89,12 @@ jobs:
           f.write(f"manylinux_base_image={BASE_IMAGE}\n")
       shell: python
       working-directory: cibuildwheel
+
+    - name: Log into internal JFrog registry
+      uses: docker/login-action@v4
+      with:
+        username: ${{ steps.setup-jf.outputs.oidc-user }}
+        password: ${{ steps.setup-jf.outputs.oidc-token }}
 
     - name: Build and push
       uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0

--- a/.github/workflows/update-manylinux-openssl-image.yml
+++ b/.github/workflows/update-manylinux-openssl-image.yml
@@ -49,7 +49,7 @@ jobs:
     - uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
       id: meta
       with:
-        images: ${{ env.MANYLINUX_TAG }}_${{ matrix.arch-and-runner-os[0] }}
+        images: aerospike.jfrog.io/database-docker-prod-internal-local/${{ env.MANYLINUX_TAG }}_${{ matrix.arch-and-runner-os[0] }}
         # These images aren't used by customers, anyway.
         flavor: latest=false
 
@@ -93,6 +93,7 @@ jobs:
     - name: Log into internal JFrog registry
       uses: docker/login-action@v4
       with:
+        registry: aerospike.jfrog.io
         username: ${{ steps.setup-jf.outputs.oidc-user }}
         password: ${{ steps.setup-jf.outputs.oidc-token }}
 

--- a/.github/workflows/update-manylinux-openssl-image.yml
+++ b/.github/workflows/update-manylinux-openssl-image.yml
@@ -44,7 +44,7 @@ jobs:
       id: setup-jf
       uses: jfrog/setup-jfrog-cli@1641575d87647fb969c0545f0b6a76873e328b7c # v5.0.0
       env:
-        JF_URL: ${{ vars.JF_URL }}
+        JF_URL: ${{ vars.JF_EXTERNAL_URL }}
       with:
         version: '2.92.0'
         oidc-provider-name: ${{ vars.OIDC_PROVIDER_NAME }}
@@ -53,7 +53,7 @@ jobs:
     - uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
       id: meta
       with:
-        images: aerospike.jfrog.io/${{ vars.JFROG_REPO_FOR_CUSTOM_MANYLINUX_IMAGES }}/${{ env.MANYLINUX_TAG }}_${{ matrix.arch-and-runner-os[0] }}
+        images: ${{ vars.JF_INTERNAL_URL }}/${{ vars.JFROG_REPO_FOR_CUSTOM_MANYLINUX_IMAGES }}/${{ env.MANYLINUX_TAG }}_${{ matrix.arch-and-runner-os[0] }}
         # These images aren't used by customers, anyway.
         flavor: latest=false
 
@@ -97,7 +97,7 @@ jobs:
     - name: Log into internal JFrog registry
       uses: docker/login-action@v4
       with:
-        registry: aerospike.jfrog.io
+        registry: ${{ vars.JF_INTERNAL_URL }}
         username: ${{ steps.setup-jf.outputs.oidc-user }}
         password: ${{ steps.setup-jf.outputs.oidc-token }}
 

--- a/.github/workflows/update-manylinux-openssl-image.yml
+++ b/.github/workflows/update-manylinux-openssl-image.yml
@@ -44,7 +44,7 @@ jobs:
       id: setup-jf
       uses: jfrog/setup-jfrog-cli@1641575d87647fb969c0545f0b6a76873e328b7c # v5.0.0
       env:
-        JF_URL: https://artifact.aerospike.io
+        JF_URL: ${{ vars.JF_URL }}
       with:
         version: '2.92.0'
         oidc-provider-name: ${{ vars.OIDC_PROVIDER_NAME }}

--- a/.github/workflows/update-manylinux-openssl-image.yml
+++ b/.github/workflows/update-manylinux-openssl-image.yml
@@ -53,7 +53,7 @@ jobs:
     - uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
       id: meta
       with:
-        images: aerospike.jfrog.io/database-docker-dev-local/${{ env.MANYLINUX_TAG }}_${{ matrix.arch-and-runner-os[0] }}
+        images: aerospike.jfrog.io/${{ vars.JFROG_REPO_FOR_CUSTOM_MANYLINUX_IMAGES }}/${{ env.MANYLINUX_TAG }}_${{ matrix.arch-and-runner-os[0] }}
         # These images aren't used by customers, anyway.
         flavor: latest=false
 


### PR DESCRIPTION
Prep work for moving to shared workflows

## TODO (after merge)
- [x] aerospike.jfrog.io vs artifact.aerospike.io difference?
- [x] Delete internal JFrog url var if no longer needed
- [ ] Delete ghcr.io manylinux images if no longer needed

## Known issues
- ~~Using artifact.aerospike.io to pull images fails.~~ Fixed