### PR TITLE
[CLIENT-4831] Fix inaccurate description about passing None as set name in `client.query_apply()` and `Query` class

### DIFF
--- a/doc/client.rst
+++ b/doc/client.rst
@@ -676,7 +676,7 @@ User Defined Functions
         This method blocks until the query is complete.
 
         :param str ns: the namespace in the aerospike cluster.
-        :param str set: the set name. Should be :py:obj:`None` if you want to query records in the *ns* which are in no set.
+        :param str set: the set name. Should be :py:obj:`None` if you want to query all records in the *ns* including ones that don't belong to a set.
         :param tuple predicate: the `tuple` produced by one of the :mod:`aerospike.predicates` methods.
         :param str module: the name of the UDF module.
         :param str function: the name of the UDF to apply to the records matched by the query.

--- a/doc/query.rst
+++ b/doc/query.rst
@@ -13,8 +13,7 @@ Constructing A Query
 --------------------
 
 The query object is used for executing queries over a secondary index of a specified set.
-It can be created by calling :meth:`aerospike.Client.query`. If the set is initialized to :py:obj:`None`,
-then the query will only apply to records without a set.
+It can be created by calling :meth:`aerospike.Client.query`.
 
 .. warning:: :meth:`aerospike.Query` should not be called directly to create a :class:`~aerospike.Query` object.
 

--- a/test/new_tests/test_query_apply.py
+++ b/test/new_tests/test_query_apply.py
@@ -168,7 +168,7 @@ class TestQueryApply(object):
         )
 
         self._wait_for_query_complete(query_id)
-        self._items_without_set_have_been_applied()
+        self._correct_items_have_been_applied()
 
     def test_query_apply_with_incorrect_policy(self):
         """

--- a/test/new_tests/test_query_apply.py
+++ b/test/new_tests/test_query_apply.py
@@ -168,7 +168,7 @@ class TestQueryApply(object):
         )
 
         self._wait_for_query_complete(query_id)
-        self._correct_items_have_been_applied()
+        self._all_ns_items_have_been_applied()
 
     def test_query_apply_with_incorrect_policy(self):
         """
@@ -476,14 +476,14 @@ class TestQueryApply(object):
         _, _, bins = self.as_connection.get(self.no_set_key)
         assert bins["name"] != "aerospike"
 
-    def _items_without_set_have_been_applied(self):
+    def _all_ns_items_have_been_applied(self):
         for i in range(1, 10):
             key = ("test", "demo", i)
             _, _, bins = self.as_connection.get(key)
-            if TestBaseClass.major_ver < 6 or (TestBaseClass.major_ver == 6 and TestBaseClass.minor_ver == 0):
-                assert bins["name"] != "aerospike"
+            if i <= 4:
+                assert bins["name"] == "aerospike"
             else:
-                assert bins["name"] == "aerospike" or bins["name"] == str(i)
+                assert bins["name"] == str(i)
 
         _, _, bins = self.as_connection.get(self.no_set_key)
         assert bins["name"] == "aerospike"


### PR DESCRIPTION
## Extra changes

- Modify client.query_apply() test case to provide better signals on whether all records in the namespace were applied when None is passed to set parameter. Previously, this test didn't care if the records in set "demo" were changed by this command or not

https://aerospike-python-client--1070.org.readthedocs.build/en/1070/client.html#aerospike.Client.query_apply
https://aerospike-python-client--1070.org.readthedocs.build/en/1070/client.html#aerospike.Client.query