### PR TITLE
[CLIENT-4843] Docs: add missing type for client config option "shm_key"

### DIFF
--- a/doc/aerospike.rst
+++ b/doc/aerospike.rst
@@ -606,7 +606,7 @@ Only the `hosts` key is required; the rest of the keys are optional.
                 Take over tending if the cluster hasn't been checked for this many seconds
 
                 Default: ``30``
-            * **shm_key**
+            * **shm_key** (:class:`int`)
                 Explicitly set the shm key for this client.
 
                 If **use_shared_connection** is not set, or set to ``False``, the user must provide a value for this field in order for shared memory to work correctly.

--- a/test/new_tests/test_client_config_level_options.py
+++ b/test/new_tests/test_client_config_level_options.py
@@ -318,6 +318,7 @@ def test_config_level_misc_options():
     config["shm"]["max_namespaces"] = 8
     config["shm"]["max_nodes"] = 3
     config["shm"]["takeover_threshold_sec"] = 30
+    config["shm"]["shm_key"] = "1000"
     config["tls"]["crl_check"] = True
     config["tls"]["crl_check_all"] = True
     config["tls"]["log_session_info"] = True


### PR DESCRIPTION
Extra changes:
- Add missing test case for shm_key option when validate_keys is true

## Manual testing

https://aerospike-python-client--1071.org.readthedocs.build/en/1071/aerospike.html#:~:text=Default:%2030-,shm_key,-(int