### PR TITLE
[CLIENT-4855] CI/CD: Fix printing server container logs causing jobs to be delayed by at least a few minutes

### DIFF
--- a/.github/workflows/aerospike-ce.conf
+++ b/.github/workflows/aerospike-ce.conf
@@ -5,7 +5,7 @@ service {
 
 logging {
     console {
-        context any detail
+        context any debug
     }
 }
 

--- a/.github/workflows/aerospike.conf
+++ b/.github/workflows/aerospike.conf
@@ -10,7 +10,7 @@ security {
 
 logging {
     console {
-        context any detail
+        context any debug
     }
 }
 

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -395,6 +395,6 @@ jobs:
 
     - if: ${{ !cancelled() }}
       run: |
-        docker logs "$CONTAINER_NAME"
+        docker logs --tail 100 "$CONTAINER_NAME"
       env:
         CONTAINER_NAME: ${{ steps.setup-aerospike-server.outputs.container-names }}

--- a/.github/workflows/test-artifact.yml
+++ b/.github/workflows/test-artifact.yml
@@ -332,7 +332,7 @@ jobs:
         # For debugging: get log size (logs can take from a few minutes to over 20 minutes to print. This hasn't happened before the release bundle PR was merged)
         if [[ "${{ runner.os }}" != "Windows" ]]; then
           log_file_path=$(docker inspect --format='{{.LogPath}}' "$CONTAINER_NAME")
-          du -h "$log_file_path"
+          sudo du -h "$log_file_path"
         fi
         docker logs "$CONTAINER_NAME"
       shell: bash

--- a/.github/workflows/test-artifact.yml
+++ b/.github/workflows/test-artifact.yml
@@ -332,7 +332,7 @@ jobs:
         # For debugging: get log size (logs can take from a few minutes to over 20 minutes to print. This hasn't happened before the release bundle PR was merged)
         if [[ "${{ runner.os }}" != "Windows" ]]; then
           log_file_path=$(docker inspect --format='{{.LogPath}}' "$CONTAINER_NAME")
-          sudo du -h "$log_file_path"
+          du -h "$log_file_path"
         fi
         docker logs "$CONTAINER_NAME"
       shell: bash

--- a/.github/workflows/test-artifact.yml
+++ b/.github/workflows/test-artifact.yml
@@ -328,13 +328,7 @@ jobs:
 
     - name: Show server logs to debug test results
       if: ${{ always() && inputs.run-integration-tests && steps.run-server.conclusion == 'success' }}
-      run: |
-        # For debugging: get log size (logs can take from a few minutes to over 20 minutes to print. This hasn't happened before the release bundle PR was merged)
-        if [[ "${{ runner.os }}" != "Windows" ]]; then
-          log_file_path=$(docker inspect --format='{{.LogPath}}' "$CONTAINER_NAME")
-          du -h "$log_file_path"
-        fi
-        docker logs "$CONTAINER_NAME"
+      run: docker logs "$CONTAINER_NAME"
       shell: bash
       env:
         CONTAINER_NAME: ${{ steps.run-server.outputs.container-name }}

--- a/.github/workflows/test-artifact.yml
+++ b/.github/workflows/test-artifact.yml
@@ -328,7 +328,13 @@ jobs:
 
     - name: Show server logs to debug test results
       if: ${{ always() && inputs.run-integration-tests && steps.run-server.conclusion == 'success' }}
-      run: docker logs "$CONTAINER_NAME"
+      run: |
+        # For debugging: get log size (logs can take from a few minutes to over 20 minutes to print. This hasn't happened before the release bundle PR was merged)
+        if [[ "${{ runner.os }}" != "Windows" ]]; then
+          log_file_path=$(docker inspect --format='{{.LogPath}}' "$CONTAINER_NAME")
+          du -h "$log_file_path"
+        fi
+        docker logs "$CONTAINER_NAME"
       shell: bash
       env:
         CONTAINER_NAME: ${{ steps.run-server.outputs.container-name }}


### PR DESCRIPTION
## Why this is important

Most of the CI/CD jobs now use a reusable workflow to run the Python client dev tests. If printing the server logs causes jobs to delay or hang, this may interfere with future development. It also makes it harder to review valgrind logs to check for memory leaks.

Log level was changed from DEBUG to DETAIL (more verbose than the former). I didn't notice this before merging the PR for supporting release bundles.

## Test plan
- [x] Reproduce issue in workflow run in `dev` which uses DETAIL level. [Workflow run on latest dev](https://github.com/aerospike/aerospike-client-python/actions/runs/26545959033/job/78198095353). It takes over 2 minutes to print the server logs.
- [x] Compare with baseline workflow run in `stage` which uses DEBUG level. [In progress workflow run on stage](https://github.com/aerospike/aerospike-client-python/actions/runs/26596325112). It takes ~1 second to print all the server logs
- [x] Test that the issue no longer exists in this feature branch with DEBUG level set again. [Workflow run with only manylinux_x86_64](https://github.com/aerospike/aerospike-client-python/actions/runs/26596886776/job/78370519857#step:19:35). The server logs now takes ~1 second to fully print.
- [x] [Build artifacts](https://github.com/aerospike/aerospike-client-python/actions/runs/26596200164) on this branch also shows similar results when spot checking the macOS and Windows jobs. (a few jobs are failing due to network / test noise)

All steps here should use the same platform tag and server tag:
- manylinux_x86_64
- Python 3.11
- AS server 8.1.2.1