### PR TITLE
[CLIENT-4862] CI/CD: Enable flag for tracing commands (-x) in bash when running setup-aerospike-server shared action

### DIFF
--- a/.github/actions/setup-server-and-tests/action.yml
+++ b/.github/actions/setup-server-and-tests/action.yml
@@ -35,7 +35,7 @@ runs:
   using: "composite"
   steps:
   # Start up server
-  - uses: aerospike/shared-workflows/.github/actions/setup-aerospike-server@91bde550339d432d99123d871c7eee628aa39587
+  - uses: aerospike/shared-workflows/.github/actions/setup-aerospike-server@bd168dedaa4fc0b17a560541779d815540eded2d # v3.7.0
     id: setup-as-server
     with:
       server-container-repo: database-docker-virtual/aerospike-server${{ inputs.server-edition == 'enterprise' && '-enterprise' || '' }}

--- a/.github/actions/setup-server-and-tests/action.yml
+++ b/.github/actions/setup-server-and-tests/action.yml
@@ -51,6 +51,7 @@ runs:
       # Problem is the shared action is overriding the entrypoint script that parses this env var
       # env-vars: DEFAULT_TTL=2592000;
       config-file: ./.github/workflows/aerospike${{ inputs.server-edition == 'community' && '-ce' || '' }}.conf
+      enable-bash-trace-mode: "true"
 
   - name: Get config.conf
     run: |

--- a/.github/actions/setup-server-and-tests/action.yml
+++ b/.github/actions/setup-server-and-tests/action.yml
@@ -35,7 +35,7 @@ runs:
   using: "composite"
   steps:
   # Start up server
-  - uses: aerospike/shared-workflows/.github/actions/setup-aerospike-server@CLIENT-4793-setup-aerospike-server-use-named-volumes-instead-of-bind-mounts-to-support-windows-and-macos-runners
+  - uses: aerospike/shared-workflows/.github/actions/setup-aerospike-server@91bde550339d432d99123d871c7eee628aa39587
     id: setup-as-server
     with:
       server-container-repo: database-docker-virtual/aerospike-server${{ inputs.server-edition == 'enterprise' && '-enterprise' || '' }}

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -378,7 +378,7 @@ jobs:
     - run: python3 -m pip install ./*.whl
 
     - id: setup-aerospike-server
-      uses: aerospike/shared-workflows/.github/actions/setup-aerospike-server@CLIENT-4793-setup-aerospike-server-use-named-volumes-instead-of-bind-mounts-to-support-windows-and-macos-runners
+      uses: aerospike/shared-workflows/.github/actions/setup-aerospike-server@91bde550339d432d99123d871c7eee628aa39587
       with:
         enable-security: ${{ startsWith(matrix.test-script-args, 'true') }}
         num-nodes: 1

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -378,7 +378,7 @@ jobs:
     - run: python3 -m pip install ./*.whl
 
     - id: setup-aerospike-server
-      uses: aerospike/shared-workflows/.github/actions/setup-aerospike-server@91bde550339d432d99123d871c7eee628aa39587
+      uses: aerospike/shared-workflows/.github/actions/setup-aerospike-server@bd168dedaa4fc0b17a560541779d815540eded2d # v3.7.0
       with:
         enable-security: ${{ startsWith(matrix.test-script-args, 'true') }}
         num-nodes: 1

--- a/.github/workflows/test-artifact.yml
+++ b/.github/workflows/test-artifact.yml
@@ -147,7 +147,7 @@ jobs:
 
         echo "ARTIFACT_FILE_NAME=${artifact_names[0]}" >> "$GITHUB_ENV"
       # For seeing how many artifacts were pulled from github
-      shell: bash -x {0}
+      shell: bash -ex {0}
 
     # Bare metal steps
 


### PR DESCRIPTION
- Point the shared setup-aerospike-server action to a revision in `main` so we can eventually delete the `shared-workflows` feature branch
- Fix sanity test for artifact count not working if an artifact fails to be found or too many artifacts are selected