### PR TITLE
[CLIENT-4868] Treat all warnings as errors when building the Python client C code

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ include_dirs = ['src/include'] + \
     ['/usr/local/opt/openssl/include'] + \
     ['aerospike-client-c/modules/common/src/include']
 extra_compile_args = [
-    '-std=gnu99', '-g', '-Wall', '-Werror', '-fPIC', '-DDEBUG', '-O1',
+    '-std=gnu99', '-g', '-Wall', '-fPIC', '-DDEBUG', '-O1',
     '-fno-common', '-fno-strict-aliasing',
     '-D_FILE_OFFSET_BITS=64', '-D_REENTRANT',
     '-DMARCH_' + machine,
@@ -161,7 +161,10 @@ elif LINUX:
     # Linux Specific Compiler and Linker Settings
     # ---------------------------------------------------------------------------
     extra_compile_args = extra_compile_args + [
-        '-rdynamic', '-finline-functions'
+        '-rdynamic', '-finline-functions',
+        # On macOS, this flag causes compiler errors. This will be addressed later
+        # CLIENT-4869
+        '-Werror'
     ]
     libraries = libraries + ['rt']
     AEROSPIKE_C_TARGET = AEROSPIKE_C_HOME + '/target/Linux-' + machine

--- a/setup.py
+++ b/setup.py
@@ -162,7 +162,7 @@ elif LINUX:
     # ---------------------------------------------------------------------------
     extra_compile_args = extra_compile_args + [
         '-rdynamic', '-finline-functions',
-        # On macOS, this flag causes compiler errors. This will be addressed later
+        # TODO: On macOS, this flag causes compiler errors
         # CLIENT-4869
         '-Werror'
     ]

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ include_dirs = ['src/include'] + \
     ['/usr/local/opt/openssl/include'] + \
     ['aerospike-client-c/modules/common/src/include']
 extra_compile_args = [
-    '-std=gnu99', '-g', '-Wall', '-fPIC', '-DDEBUG', '-O1',
+    '-std=gnu99', '-g', '-Wall', '-Werror', '-fPIC', '-DDEBUG', '-O1',
     '-fno-common', '-fno-strict-aliasing',
     '-D_FILE_OFFSET_BITS=64', '-D_REENTRANT',
     '-DMARCH_' + machine,


### PR DESCRIPTION
This addresses a regression introduced in efc712f9df85c8366f6e81c03a66316a84868971 when reusing the test-artifact workflow for the smoke tests

## Extra changes
- This also builds the manylinux (production) wheels using -Werror. This change is fine since the manylinux wheels successfully compile.

## Test plan
- I rebased this PR https://github.com/aerospike/aerospike-client-python/pull/1074 onto this branch. Previously, this branch's smoke tests were building the client successfully. After rebasing the PR, the branch now correctly reports all warnings as errors
- Build artifacts: client successfully builds for all platforms