### PR TITLE
[CLIENT-5089] CI/CD: Bump transitive dependencies to address critical and high vulnerabilities

### DIFF
--- a/.github/workflows/package-lock.json
+++ b/.github/workflows/package-lock.json
@@ -831,9 +831,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"

--- a/.github/workflows/package-lock.json
+++ b/.github/workflows/package-lock.json
@@ -1719,9 +1719,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
-      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"


### PR DESCRIPTION
Had to make this PR manually because dependabot / Snyk was unable to create a PR for this fix.

Bumping `undici` to 6.27.0 addresses the following vulnerabilities:

- [CWE-93](https://cwe.mitre.org/data/definitions/93.html)
- [CWE-183](https://cwe.mitre.org/data/definitions/183.html)
- [CWE-770](https://cwe.mitre.org/data/definitions/770.html)

Bumping `brace-expansion` to 2.1.2 addresses the following vulnerability:

- [CWE-407](https://cwe.mitre.org/data/definitions/407.html)