### PR TITLE
[CLIENT-4158] Add missing cross reference from client API docs to server boolean type in aerospike.com docs

### DIFF
--- a/doc/aerospike.rst
+++ b/doc/aerospike.rst
@@ -1243,7 +1243,7 @@ Specifies how the Python client will write Python booleans.
 
 .. data:: INTEGER
 
-    Write Python Booleans as integers.
+    Write Python Booleans as `server integers <https://aerospike.com/docs/develop/data-types/scalar/#integer>`_.
 
 .. data:: AS_BOOL
 

--- a/doc/aerospike.rst
+++ b/doc/aerospike.rst
@@ -1247,9 +1247,7 @@ Specifies how the Python client will write Python booleans.
 
 .. data:: AS_BOOL
 
-    Write Python Booleans as ``as_bools``.
-
-    This is the Aerospike server's boolean type.
+    Write Python Booleans as `server booleans <https://aerospike.com/docs/develop/data-types/scalar/#boolean>`_.
 
 List
 ----


### PR DESCRIPTION
This closes out CLIENT-4158

https://aerospike-python-client--1173.org.readthedocs.build/en/1173/aerospike.html#send-bool-constants