### PR TITLE
[CLIENT-5193] Fix leak when receiving AS_BYTES_PYTHON-type values from the server

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -418,13 +418,13 @@ jobs:
     - id: setup-aerospike-server
       uses: aerospike/shared-workflows/.github/actions/setup-aerospike-server@bd168dedaa4fc0b17a560541779d815540eded2d # v3.7.0
       with:
-        enable-security: ${{ startsWith(matrix.test-script-args, 'true') }}
+        enable-security: ${{ startsWith(matrix.test-script-args, './test-user-agent-e2e.bash true') }}
         num-nodes: 1
         oidc-provider: ${{ vars.OIDC_PROVIDER_NAME }}
         oidc-audience: ${{ vars.OIDC_AUDIENCE }}
         features-content: ${{ secrets.FEATURES_CONTENT }}
         server-tag: ${{ needs.get-env-vars.outputs.server-tag }}
-        server-container-repo: database-docker-virtual/aerospike-server${{ startsWith(matrix.test-script-args, 'true') && '-enterprise' || '' }}
+        server-container-repo: database-docker-virtual/aerospike-server${{ startsWith(matrix.test-script-args, './test-user-agent-e2e.bash true') && '-enterprise' || '' }}
 
     - if: ${{ contains(matrix.test-script-args, 'deserialize_as_bytes_python') }}
       name: Install Python client that supports inserting AS_BYTES_PYTHON

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -398,7 +398,7 @@ jobs:
           - "./test-user-agent-e2e.bash false"
           - "./test-user-agent-e2e.bash true"
           - "./test-user-agent-e2e.bash true my_app_id"
-          - "PYTHONMALLOC=malloc valgrind --leak-check=full --show-leak-kinds=definite --error-for-leak-kinds=definite python3 ./test_deserialize_as_bytes_python.py"
+          - "python3 ./test_deserialize_as_bytes_python.py"
     runs-on: ${{ needs.build.outputs.runner-os-used-for-build }}
     steps:
     - name: Harden the runner (Audit all outbound calls)

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -386,7 +386,7 @@ jobs:
       working-directory: test/standalone
 
   # This is an e2e test to check that the user agent was sent correctly to the server
-  test-user-agent:
+  test-standalone:
     needs: [
       build,
       get-env-vars
@@ -395,9 +395,10 @@ jobs:
       fail-fast: false
       matrix:
         test-script-args:
-          - "false"
-          - "true"
-          - "true my_app_id"
+          - "./test-user-agent-e2e.bash false"
+          - "./test-user-agent-e2e.bash true"
+          - "./test-user-agent-e2e.bash true my_app_id"
+          - "python3 ./test_deserialize_as_bytes_python.py"
     runs-on: ${{ needs.build.outputs.runner-os-used-for-build }}
     steps:
     - name: Harden the runner (Audit all outbound calls)
@@ -413,7 +414,6 @@ jobs:
     - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         pattern: ${{ vars.GH_ARTIFACT_NAME_PREFIX_FOR_BUILDS }}-${{ env.LOWEST_SUPPORTED_PY_VERSION }}-${{ env.PLATFORM_TAG }}
-    - run: python3 -m pip install ./*.whl
 
     - id: setup-aerospike-server
       uses: aerospike/shared-workflows/.github/actions/setup-aerospike-server@bd168dedaa4fc0b17a560541779d815540eded2d # v3.7.0
@@ -426,9 +426,18 @@ jobs:
         server-tag: ${{ needs.get-env-vars.outputs.server-tag }}
         server-container-repo: database-docker-virtual/aerospike-server${{ startsWith(matrix.test-script-args, 'true') && '-enterprise' || '' }}
 
+    - if: ${{ contains(matrix.test-script-args, 'deserialize_as_bytes_python') }}
+      name: Install Python client that supports inserting AS_BYTES_PYTHON
+      run: |
+        python3 -m pip install aerospike==12.*
+        python3 ./insert_as_bytes_python.py
+      working-directory: test/standalone
+
+    - run: python3 -m pip install ./*.whl
+
       # Even for server versions < 8.1 that don't support user agent, this client version should still work on older servers
     - name: Run client in background
-      run: ./test-user-agent-e2e.bash ${{ matrix.test-script-args }}
+      run: ${{ matrix.test-script-args }}
       working-directory: test/standalone
 
     - if: ${{ !cancelled() }}

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -398,7 +398,7 @@ jobs:
           - "./test-user-agent-e2e.bash false"
           - "./test-user-agent-e2e.bash true"
           - "./test-user-agent-e2e.bash true my_app_id"
-          - "python3 ./test_deserialize_as_bytes_python.py"
+          - "PYTHONMALLOC=malloc valgrind --leak-check=full --show-leak-kinds=definite --error-for-leak-kinds=definite python3 ./test_deserialize_as_bytes_python.py"
     runs-on: ${{ needs.build.outputs.runner-os-used-for-build }}
     steps:
     - name: Harden the runner (Audit all outbound calls)

--- a/src/main/serializer.c
+++ b/src/main/serializer.c
@@ -429,6 +429,7 @@ extern as_status deserialize_based_on_as_bytes_type(AerospikeClient *self,
         }
         *retval = py_val;
         as_error_update(error_p, AEROSPIKE_OK, NULL);
+        break;
     case AS_BYTES_BLOB: {
         if (self->user_deserializer_call_info.callback) {
             execute_user_callback(&self->user_deserializer_call_info, &bytes,

--- a/test/standalone/insert_as_bytes_python.py
+++ b/test/standalone/insert_as_bytes_python.py
@@ -1,0 +1,15 @@
+import aerospike
+
+config = {
+    "hosts": [
+        ("127.0.0.1", 3000)
+    ],
+    "send_bool_as": aerospike.PY_BYTES
+}
+client = aerospike.client(config)
+
+bins = {"a": True}
+key = ("test", "demo", 1)
+client.put(key, bins=bins)
+
+client.close()

--- a/test/standalone/test_deserialize_as_bytes_python.py
+++ b/test/standalone/test_deserialize_as_bytes_python.py
@@ -1,0 +1,15 @@
+import aerospike
+
+config = {
+    "hosts": [
+        ("127.0.0.1", 3000)
+    ],
+}
+client = aerospike.client(config)
+
+key = ("test", "demo", 1)
+_, _, bins = client.get(key)
+print(bins["a"])
+assert isinstance(bins["a"], bytearray)
+
+client.close()


### PR DESCRIPTION
Fix bug where AS_BYTES_PYTHON are returned as bytes instead of bytearrays

This seems to be affecting customers in production, so I would like to merge this in ASAP

## TODO
- [ ] Mention co-author in commit description