### PR TITLE
[CLIENT-4836] Fix string expression RegexReplace's flags parameter not working

### DIFF
--- a/test/new_tests/test_expressions_string.py
+++ b/test/new_tests/test_expressions_string.py
@@ -4,7 +4,7 @@ import base64
 from aerospike_helpers.expressions import string as str_expr, IntBin, FloatBin, BlobBin
 from aerospike_helpers.operations import expression_operations as expr_ops
 from aerospike_helpers.operations import operations
-from aerospike_helpers.string_helpers import NumericType, RegexFlags
+from aerospike_helpers.string_helpers import NumericType, RegexFlags, WriteFlags
 from aerospike import exception as e
 
 from .test_base_class import TestBaseClass
@@ -249,6 +249,10 @@ class TestExpressions:
             ),
             (
                 str_expr.RegexReplace, {"pattern": "asdf", "replacement": "1234", "regex_flags": RegexFlags.DEFAULT, "bin": STR_BIN_NAME},
+                "1234asdf"
+            ),
+            (
+                str_expr.RegexReplace, {"pattern": "ASDF", "replacement": "1234", "regex_flags": RegexFlags.DEFAULT | RegexFlags.CASE_INSENSITIVE, "bin": STR_BIN_NAME},
                 "1234asdf"
             )
         ]

--- a/test/new_tests/test_string_operations.py
+++ b/test/new_tests/test_string_operations.py
@@ -472,8 +472,6 @@ class TestStringOperations:
             assert bins[bin_name] == expected_results
 
     @expect_server_version_earlier_than_8_1_3_to_fail
-    @pytest.mark.xfail(reason="Currently the latest server 8.1.3 dev build does not respect NO_FAIL when no" \
-    " ctx argument is provided")
     def test_string_policy_no_fail(self):
         policy = StringPolicy(write_flags=WriteFlags.NO_FAIL)
         ops = [


### PR DESCRIPTION
## Extra changes

- Remove xfail flag from test case that was fixed in server commit `3083f6c`

## TODO

- [x] ~~Waiting for QE to verify this branch fixes their failing test case~~ Independently verified that this fix works