### PR TITLE
[CLIENT-4053]: fix set name validation in scan method

### DIFF
--- a/src/main/scan/type.c
+++ b/src/main/scan/type.c
@@ -155,6 +155,13 @@ static int AerospikeScan_Type_Init(AerospikeScan *self, PyObject *args,
         else if (Py_None == py_set) {
             set = NULL;
         }
+        else {
+            as_error_init(&err);
+            as_error_update(&err, AEROSPIKE_ERR_PARAM,
+                            "Set should be string, unicode or None");
+            raise_exception(&err);
+            return -1;
+        }
     }
 
     self->unicodeStrVector = NULL;

--- a/test/new_tests/test_scan.py
+++ b/test/new_tests/test_scan.py
@@ -404,19 +404,14 @@ class TestScan(TestBaseClass):
         err_code = err_info.value.code
         assert err_code == AerospikeStatus.AEROSPIKE_ERR_PARAM
 
-    @pytest.mark.parametrize(
-        "invalid_set",
-        [123, 1.5, ["a_set"], {"a_set": 1}, (1, 2)],
-        ids=["int", "float", "list", "dict", "tuple"],
-    )
-    def test_scan_with_invalid_set_type(self, invalid_set):
+    def test_scan_with_invalid_set_type(self):
         """
         Invoke scan() with a set argument that is neither a string nor None.
         This should raise a ParamError instead of silently scanning the
         entire namespace (CLIENT-4053).
         """
         with pytest.raises(e.ParamError) as err_info:
-            self.as_connection.scan(self.test_ns, invalid_set)
+            self.as_connection.scan(self.test_ns, 123)
 
         assert err_info.value.code == AerospikeStatus.AEROSPIKE_ERR_PARAM
         assert err_info.value.msg == "Set should be string, unicode or None"

--- a/test/new_tests/test_scan.py
+++ b/test/new_tests/test_scan.py
@@ -404,6 +404,23 @@ class TestScan(TestBaseClass):
         err_code = err_info.value.code
         assert err_code == AerospikeStatus.AEROSPIKE_ERR_PARAM
 
+    @pytest.mark.parametrize(
+        "invalid_set",
+        [123, 1.5, ["a_set"], {"a_set": 1}, (1, 2)],
+        ids=["int", "float", "list", "dict", "tuple"],
+    )
+    def test_scan_with_invalid_set_type(self, invalid_set):
+        """
+        Invoke scan() with a set argument that is neither a string nor None.
+        This should raise a ParamError instead of silently scanning the
+        entire namespace (CLIENT-4053).
+        """
+        with pytest.raises(e.ParamError) as err_info:
+            self.as_connection.scan(self.test_ns, invalid_set)
+
+        assert err_info.value.code == AerospikeStatus.AEROSPIKE_ERR_PARAM
+        assert err_info.value.msg == "Set should be string, unicode or None"
+
     def test_scan_with_select_bin_integer(self):
         """
         Invoke scan() with select bin is of type integer.


### PR DESCRIPTION
Fixes: https://aerospike.atlassian.net/browse/CLIENT-4053

## Summary

Fixes `client.scan()` silently scanning the entire namespace when passed a `set` argument that isn't a string or `None` (e.g. an int, float, list, dict, or tuple). `AerospikeScan_Type_Init` (`src/main/scan/type.c`) now raises a `ParamError` ("Set should be string, unicode or None") for any non-string/non-`None` set value, matching the validation already done for other scan/query parameters.

## Changes

- `src/main/scan/type.c`: added an `else` branch to the set-type check that raises `AEROSPIKE_ERR_PARAM` instead of falling through.
- `test/new_tests/test_scan.py`: added `test_scan_with_invalid_set_type`, asserting `scan(ns, 123)` raises `ParamError` with the expected code/message.

## Test plan

- [x] `python3 -m pytest new_tests/test_scan.py::TestScan::test_scan_with_invalid_set_type -v` passes
- [x] Full `new_tests/test_scan*.py` suite run to confirm no regressions in existing scan calls (all pass string/`None` set args)
