### PR TITLE
[CLIENT-4841]: fix connection method formats

### DIFF
--- a/doc/aerospike.rst
+++ b/doc/aerospike.rst
@@ -516,13 +516,24 @@ Only the `hosts` key is required; the rest of the keys are optional.
                 aerospike.exception.ParamError: "key_policy" is an invalid policy dictionary key
 
         * **hosts** (:class:`list`)
-            A list of tuples identifying a node (or multiple nodes) in the cluster.
+            A list identifying a node (or multiple nodes) in the cluster. Each entry may be
+            either a tuple or a string.
 
             The tuple is in this format: ``(address, port, [tls-name])``
 
             * address: :class:`str`
             * port: :class:`int`
             * tls-name: :class:`str`
+
+            The string form is ``"address[:tls-name]:[port]"``, e.g.:
+
+            * ``"address:port"``
+            * ``"address:tls-name:port"``
+            * ``"[ipv6-address]:port"``
+            * ``"[ipv6-address]:tls-name:port"``
+
+            IPv6 addresses must be enclosed in square brackets to distinguish the address's
+            own colons from the ``:tls-name`` and ``:port`` separators.
 
             The client will connect to the first available node in the list called the *seed node*.
             From there, it will learn about the cluster and its partition map.

--- a/doc/spelling_wordlist.txt
+++ b/doc/spelling_wordlist.txt
@@ -112,3 +112,5 @@ backpressure
 MRT
 ns
 jittered
+IPv4
+IPv6

--- a/doc/spelling_wordlist.txt
+++ b/doc/spelling_wordlist.txt
@@ -112,5 +112,4 @@ backpressure
 MRT
 ns
 jittered
-IPv4
-IPv6
+IPv

--- a/src/main/client/type.c
+++ b/src/main/client/type.c
@@ -788,24 +788,34 @@ static int AerospikeClient_Type_Init(AerospikeClient *self, PyObject *args,
                             strdup((char *)PyUnicode_AsUTF8(py_tls_name));
                     }
                 }
-            }
-            else if (PyUnicode_Check(py_host)) {
-                addr = strdup(strtok((char *)PyUnicode_AsUTF8(py_host), ":"));
-                addr = strtok(addr, ":");
-                char *temp = strtok(NULL, ":");
-                if (NULL != temp) {
-                    port = (uint16_t)atoi(temp);
-                }
-            }
-            if (addr) {
-                if (tls_name) {
-                    as_config_tls_add_host(&config, addr, tls_name, port);
-                    free(tls_name);
+
+                if (addr) {
+                    if (tls_name) {
+                        as_config_tls_add_host(&config, addr, tls_name, port);
+                        free(tls_name);
+                    }
+                    else {
+                        as_config_add_host(&config, addr, port);
+                    }
+                    free(addr);
                 }
                 else {
-                    as_config_add_host(&config, addr, port);
+                    error_code = INIT_INVALID_ADRR_ERR;
+                    goto CONSTRUCTOR_ERROR;
                 }
-                free(addr);
+            }
+            else if (PyUnicode_Check(py_host)) {
+                // Accepts "hostname[:tlsname][:port]", including bracketed
+                // IPv6 addresses, e.g. "host:3000", "host:tlsname:3000",
+                // "[::1]:3000", "[::1]:tlsname:3000" (CLIENT-4841). Parsing
+                // is delegated to the C client, which copies the string
+                // instead of mutating the Python-owned buffer.
+                const char *host_str = PyUnicode_AsUTF8(py_host);
+                if (!host_str ||
+                    !as_config_add_hosts(&config, host_str, port)) {
+                    error_code = INIT_INVALID_ADRR_ERR;
+                    goto CONSTRUCTOR_ERROR;
+                }
             }
             else {
                 error_code = INIT_INVALID_ADRR_ERR;

--- a/test/new_tests/test_connect.py
+++ b/test/new_tests/test_connect.py
@@ -86,11 +86,19 @@ class TestConnect(object):
 
     def test_connect_positive_string_host_and_port(self):
         """
-        Invoke connect() with a single "hostname:port" string entry
-        (CLIENT-4841).
+        Invoke connect() with a single "hostname[:tlsname]:port" string
+        entry (CLIENT-4841). connection_config's host entry has a tls-name
+        as a third tuple element when TLS is enabled, so build the
+        equivalent string for both the 2- and 3-element tuple cases.
         """
-        addr, port = self.connection_config["hosts"][0]
-        config = {"hosts": [f"{addr}:{port}"]}
+        config = self.connection_config.copy()
+        host_entry = config["hosts"][0]
+        if len(host_entry) == 3:
+            addr, port, tls_name = host_entry
+            config["hosts"] = [f"{addr}:{tls_name}:{port}"]
+        else:
+            addr, port = host_entry
+            config["hosts"] = [f"{addr}:{port}"]
 
         with open_as_connection(config) as client:
             assert client.is_connected()

--- a/test/new_tests/test_connect.py
+++ b/test/new_tests/test_connect.py
@@ -84,6 +84,17 @@ class TestConnect(object):
         with open_as_connection(config) as client:
             assert client.is_connected()
 
+    def test_connect_positive_string_host_and_port(self):
+        """
+        Invoke connect() with a single "hostname:port" string entry
+        (CLIENT-4841).
+        """
+        addr, port = self.connection_config["hosts"][0]
+        config = {"hosts": [f"{addr}:{port}"]}
+
+        with open_as_connection(config) as client:
+            assert client.is_connected()
+
     def test_connect_positive_shm_key(self):
         """
         Invoke connect() with shm_key specified
@@ -216,6 +227,14 @@ class TestConnect(object):
             # Errors that throw -10 can also throw 9
             ({"hosts": [("127.0.0.1", 2000)]}, (e.ClientError, e.TimeoutError), (-10, 9), "Failed to connect"),
             ({"hosts": [("127.0.0.1", "3000")]}, e.ParamError, -2, "Invalid host -> The host port must be an integer"),
+            # String host formats (CLIENT-4841). These target an unused
+            # address/port so parsing succeeds but the connection attempt
+            # itself fails, proving the string was accepted rather than
+            # rejected as invalid.
+            ({"hosts": ["[::1]:2000"]}, (e.ClientError, e.TimeoutError), (-10, 9), "Failed to connect"),
+            ({"hosts": ["127.0.0.1:tls1:2000"]}, (e.ClientError, e.TimeoutError), (-10, 9), "Failed to connect"),
+            ({"hosts": ["[::1]:tls1:2000"]}, (e.ClientError, e.TimeoutError), (-10, 9), "Failed to connect"),
+            ({"hosts": ["127.0.0.1:1:2:3"]}, e.ParamError, -2, "Invalid host"),
             (
                 {"hosts": [("127.0.0.1", 3000)], "user": "a" * 64, "password": "password"},
                 e.ParamError,
@@ -248,6 +267,10 @@ class TestConnect(object):
             "hosts missing address",
             "hosts port is incorrect",
             "hosts port is string",
+            "string host ipv6 and port",
+            "string host, tls name, and port",
+            "string host ipv6, tls name, and port",
+            "string host with too many colons",
             "username too long",
             "password too long",
             "username empty",

--- a/test/new_tests/test_invalid_conf.py
+++ b/test/new_tests/test_invalid_conf.py
@@ -42,6 +42,13 @@ class TestInvalidClientConfig(object):
             aerospike.client({"hosts": [("localhost", 3000), ()]})
         assert "Invalid host" in err.value.msg
 
+    def test_invalid_host_tuple_address_type(self):
+        # A correctly-sized (address, port) tuple whose address isn't a string
+        # (CLIENT-4841).
+        with pytest.raises(e.ParamError) as err:
+            aerospike.client({"hosts": [(123, 3000)]})
+        assert "Invalid host" in err.value.msg
+
     def test_lua_user_path_too_long(self):
         with pytest.raises(e.ParamError) as err:
             aerospike.client({"hosts": [("localhost", 3000)], "lua": {"user_path": "a" * 256}})


### PR DESCRIPTION
Fixes: https://aerospike.atlassian.net/browse/CLIENT-4841
## Summary

CLIENT-4841: `hosts` config entries given as a bare string (`"host:port"`) were parsed with `strtok`/`atoi` directly on a Python-owned buffer — unsafe, and unable to support TLS name or IPv6. Now delegates to the C client's `as_config_add_hosts()`, which safely supports:

- `hostname:port`
- `hostname:tlsname:port`
- `[ipv6]:port`
- `[ipv6]:tlsname:port`

## Changes

- `src/main/client/type.c`: replace manual string parsing with `as_config_add_hosts()`.
- `test/new_tests/test_connect.py`: add tests for the string host formats above (valid and invalid).

## Test plan

- [x] `pytest new_tests/test_connect.py` — all pass
- [x] Full `new_tests` suite — no new regressions
