### PR TITLE
CI/CD: update vulnerable dependencies in .github/workflows/package-lock.json.

### DIFF
--- a/.github/workflows/package-lock.json
+++ b/.github/workflows/package-lock.json
@@ -831,9 +831,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -1719,9 +1719,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"


### PR DESCRIPTION
These dependencies aren't currently being used, but will be used in the future for nightly and weekend tests

Addresses the following vulnerabilities:
- [CVE-2026-69152](https://www.cve.org/CVERecord?id=CVE-2026-69152)

NOTE: currently Snyk shows additional vulnerabilities that seem to have been addressed in 2c8f2cc49ae23f958f81443d213ff88b0030ec79. Snyk report: https://app.snyk.io/org/aerospike-clients/project/827c4f9a-d766-4536-83df-2d7ad9cc5d20.

I believe this is running against the `master` branch since the `stage` branch already has fixes for some of these high vulnerabilities.

I reran Snyk against the `stage` branch here: https://app.snyk.io/org/aerospike-clients/project/3ebb0e0e-7676-466d-9bdf-c566e134b413

And the CVE-2026-69152 vulnerability doesn't show up for some reason. But I will update it here to be safe.

Also updating undici to 6.28.0 to address medium vulnerabilities [CVE-2026-16728](https://www.cve.org/CVERecord?id=CVE-2026-16728) and [CVE-2026-16729](https://www.cve.org/CVERecord?id=CVE-2026-16729).