### PR TITLE
[CLIENT-3994] Address test regressions on server 8.1.3

### DIFF
--- a/test/new_tests/conftest.py
+++ b/test/new_tests/conftest.py
@@ -74,12 +74,34 @@ def wait_for_port(address, port, interval=0.1, timeout=60):
         time.sleep(interval)
     return False
 
+class KeysValue:
+    def __init__(self, keys, value):
+        self.keys = keys
+        self.value = value
+
+def set_nested_keys_and_val(config: dict, kv: KeysValue):
+    curr_dict = config
+    keys = kv.keys
+    value = kv.value
+    for i in range(len(keys) - 1):
+        curr_key = keys[i]
+        if curr_key not in curr_dict:
+            curr_dict[curr_key] = {}
+        curr_dict = curr_dict[curr_key]
+    curr_dict[keys[-1]] = value
 
 @pytest.fixture(scope="class")
 def as_connection(request) -> aerospike.Client:
     config = TestBaseClass.get_connection_config()
-    # TODO: remove. this is a duplicate.
-    request.cls.config = config
+
+    if hasattr(request, "param"):
+        if isinstance(request.param, KeysValue):
+
+            set_nested_keys_and_val(config, request.param)
+        else:
+            for keys_val in request.param:
+                set_nested_keys_and_val(config, keys_val)
+
     lua_user_path = os.path.join(sys.exec_prefix, "aerospike", "usr-lua")
     lua_info = {"user_path": lua_user_path}
     config["lua"] = lua_info
@@ -155,14 +177,13 @@ def connection_with_udf(request, as_connection):
     """
     Injects an as_client() as a dependency, loads a udf to it,
     and at the end of the test class removes it.
-    Note: if the requesting class does not have a class attr:
-    `udf_to_load`, this is essentially a noop
+    Note: if the requesting class does not pass in a param, this is a no-op.
     """
     udf_status = {"loaded": False, "name": None}
     # if the class doesn't have the correct information,
     # don't bother loading a UDF
-    if hasattr(request.cls, "udf_to_load"):
-        udf_status["name"] = request.cls.udf_to_load
+    if hasattr(request, "param"):
+        udf_status["name"] = request.param
         as_connection.udf_put(udf_status["name"], 0, {})
         udf_status["loaded"] = True
 
@@ -275,14 +296,16 @@ expected_number_bin_values = set()
 
 # Add records around the test
 @pytest.fixture(scope="function")
-def insert_records(request, as_connection):
+def insert_records(request, connection_with_udf):
 
     # - Some tests don't make use of unique sets,
     # so we leave them alone for backwards compatibility
     # - make_set_unique ensures that if a test case's cleanup stage fails to run
     # e.g when the test case's setup fixture fails out,
     # that test case's records does not interfere with future test cases that need to perform a query
-    num_keys, make_set_unique = request.param
+    num_keys = request.param["record_count"]
+    make_set_unique = request.param["make_set_unique"]
+    batch_write_policy = request.param.get("batch_write_command_policy", None)
 
     if make_set_unique:
         set_name = f"{TEST_SET}-{time.time_ns()}"
@@ -290,7 +313,7 @@ def insert_records(request, as_connection):
         set_name = TEST_SET
 
     if make_set_unique is False:
-        as_connection.truncate(TEST_NS, set_name, 0)
+        connection_with_udf.truncate(TEST_NS, set_name, 0)
 
     request.cls.set_name = set_name
     keys = [(TEST_NS, set_name, i) for i in range(num_keys)]
@@ -304,11 +327,11 @@ def insert_records(request, as_connection):
             operations.write(BIN_NAME, i),
             operations.write(MAP_BIN_NAME, {"a": i})
         ]
-        br = Write(key, ops=ops)
+        br = Write(key, ops=ops, policy=batch_write_policy)
         batch_records.append(br)
         expected_number_bin_values.add(i)
 
-    as_connection.batch_write(brs)
+    connection_with_udf.batch_write(brs)
 
     yield
 

--- a/test/new_tests/conftest.py
+++ b/test/new_tests/conftest.py
@@ -74,12 +74,12 @@ def wait_for_port(address, port, interval=0.1, timeout=60):
         time.sleep(interval)
     return False
 
-class KeysValue:
+class ClientConfigKeysValue:
     def __init__(self, keys, value):
         self.keys = keys
         self.value = value
 
-def set_nested_keys_and_val(config: dict, kv: KeysValue):
+def set_nested_keys_and_val(config: dict, kv: ClientConfigKeysValue):
     curr_dict = config
     keys = kv.keys
     value = kv.value
@@ -95,7 +95,7 @@ def as_connection(request) -> aerospike.Client:
     config = TestBaseClass.get_connection_config()
 
     if hasattr(request, "param"):
-        if isinstance(request.param, KeysValue):
+        if isinstance(request.param, ClientConfigKeysValue):
 
             set_nested_keys_and_val(config, request.param)
         else:

--- a/test/new_tests/conftest.py
+++ b/test/new_tests/conftest.py
@@ -323,10 +323,16 @@ def insert_records(request, connection_with_udf):
     brs = BatchRecords(batch_records=batch_records)
 
     for i, key in enumerate(keys):
-        ops = [
-            operations.write(BIN_NAME, i),
-            operations.write(MAP_BIN_NAME, {"a": i})
-        ]
+        if "bins" not in request.param:
+            ops = [
+                operations.write(BIN_NAME, i),
+                operations.write(MAP_BIN_NAME, {"a": i})
+            ]
+        else:
+            bins = request.param["bins"]
+            ops = [
+                operations.write(bin_name, value) for bin_name, value in bins.items()
+            ]
         br = Write(key, ops=ops, policy=batch_write_policy)
         batch_records.append(br)
         expected_number_bin_values.add(i)

--- a/test/new_tests/conftest.py
+++ b/test/new_tests/conftest.py
@@ -74,34 +74,12 @@ def wait_for_port(address, port, interval=0.1, timeout=60):
         time.sleep(interval)
     return False
 
-class KeysValue:
-    def __init__(self, keys, value):
-        self.keys = keys
-        self.value = value
-
-def set_nested_keys_and_val(config: dict, kv: KeysValue):
-    curr_dict = config
-    keys = kv.keys
-    value = kv.value
-    for i in range(len(keys) - 1):
-        curr_key = keys[i]
-        if curr_key not in curr_dict:
-            curr_dict[curr_key] = {}
-        curr_dict = curr_dict[curr_key]
-    curr_dict[keys[-1]] = value
 
 @pytest.fixture(scope="class")
 def as_connection(request) -> aerospike.Client:
     config = TestBaseClass.get_connection_config()
-
-    if hasattr(request, "param"):
-        if isinstance(request.param, KeysValue):
-
-            set_nested_keys_and_val(config, request.param)
-        else:
-            for keys_val in request.param:
-                set_nested_keys_and_val(config, keys_val)
-
+    # TODO: remove. this is a duplicate.
+    request.cls.config = config
     lua_user_path = os.path.join(sys.exec_prefix, "aerospike", "usr-lua")
     lua_info = {"user_path": lua_user_path}
     config["lua"] = lua_info
@@ -177,13 +155,14 @@ def connection_with_udf(request, as_connection):
     """
     Injects an as_client() as a dependency, loads a udf to it,
     and at the end of the test class removes it.
-    Note: if the requesting class does not pass in a param, this is a no-op.
+    Note: if the requesting class does not have a class attr:
+    `udf_to_load`, this is essentially a noop
     """
     udf_status = {"loaded": False, "name": None}
     # if the class doesn't have the correct information,
     # don't bother loading a UDF
-    if hasattr(request, "param"):
-        udf_status["name"] = request.param
+    if hasattr(request.cls, "udf_to_load"):
+        udf_status["name"] = request.cls.udf_to_load
         as_connection.udf_put(udf_status["name"], 0, {})
         udf_status["loaded"] = True
 
@@ -296,16 +275,14 @@ expected_number_bin_values = set()
 
 # Add records around the test
 @pytest.fixture(scope="function")
-def insert_records(request, connection_with_udf):
+def insert_records(request, as_connection):
 
     # - Some tests don't make use of unique sets,
     # so we leave them alone for backwards compatibility
     # - make_set_unique ensures that if a test case's cleanup stage fails to run
     # e.g when the test case's setup fixture fails out,
     # that test case's records does not interfere with future test cases that need to perform a query
-    num_keys = request.param["record_count"]
-    make_set_unique = request.param["make_set_unique"]
-    batch_write_policy = request.param.get("batch_write_command_policy", None)
+    num_keys, make_set_unique = request.param
 
     if make_set_unique:
         set_name = f"{TEST_SET}-{time.time_ns()}"
@@ -313,7 +290,7 @@ def insert_records(request, connection_with_udf):
         set_name = TEST_SET
 
     if make_set_unique is False:
-        connection_with_udf.truncate(TEST_NS, set_name, 0)
+        as_connection.truncate(TEST_NS, set_name, 0)
 
     request.cls.set_name = set_name
     keys = [(TEST_NS, set_name, i) for i in range(num_keys)]
@@ -327,11 +304,11 @@ def insert_records(request, connection_with_udf):
             operations.write(BIN_NAME, i),
             operations.write(MAP_BIN_NAME, {"a": i})
         ]
-        br = Write(key, ops=ops, policy=batch_write_policy)
+        br = Write(key, ops=ops)
         batch_records.append(br)
         expected_number_bin_values.add(i)
 
-    connection_with_udf.batch_write(brs)
+    as_connection.batch_write(brs)
 
     yield
 

--- a/test/new_tests/test_command_level_policies.py
+++ b/test/new_tests/test_command_level_policies.py
@@ -88,26 +88,26 @@ class CommandLevelTTL:
         verify_record_ttl(self.client, KEY, expected_ttl=self.NEW_TTL)
 
 
+TTL = 2
+
+@pytest.mark.parametrize(
+    "insert_records",
+    [{"record_count": 1, "make_set_unique": True, "batch_write_command_policy": {"ttl": TTL}}],
+    indirect=True
+)
+@pytest.mark.usefixtures("insert_records")
 class TestReadTouchTTLPercent:
     @pytest.fixture(autouse=True)
     def setup(self, as_connection):
-        ttl = 2
-        self.as_connection.put(KEY, bins={"a": 1}, policy={"ttl": ttl})
         self.policy = {
             "read_touch_ttl_percent": 50
         }
         self.invalid_policy = {
             "read_touch_ttl_percent": "1"
         }
-        self.delay = ttl / 2 + 0.1
+        self.delay = TTL / 2 + 0.1
 
         yield
-
-        # Some tests call the client remove API
-        try:
-            self.as_connection.remove(KEY)
-        except e.RecordNotFound:
-            pass
 
     def test_read_invalid(self):
         with pytest.raises(e.ParamError) as excinfo:
@@ -136,10 +136,10 @@ class TestReadTouchTTLPercent:
         time.sleep(self.delay)
         # By this time, the record's ttl should be less than 1 second left
         # Reset record TTL
-        self.as_connection.get(KEY, policy=self.policy)
+        self.as_connection.get(self.keys[0], policy=self.policy)
         time.sleep(self.delay)
         # Record should not have expired
-        self.as_connection.get(KEY)
+        self.as_connection.get(self.keys[0])
 
     def test_operate(self):
         if (TestBaseClass.major_ver, TestBaseClass.minor_ver) < (7, 1):
@@ -148,20 +148,17 @@ class TestReadTouchTTLPercent:
         ops = [
             operations.read("a")
         ]
-        self.as_connection.operate(KEY, ops, policy=self.policy)
+        self.as_connection.operate(self.keys[0], ops, policy=self.policy)
         time.sleep(self.delay)
-        self.as_connection.get(KEY)
+        self.as_connection.get(self.keys[0])
 
     def test_batch(self):
         if (TestBaseClass.major_ver, TestBaseClass.minor_ver) < (7, 1):
             pytest.skip(SKIP_MSG)
         time.sleep(self.delay)
-        keys = [
-            KEY
-        ]
-        self.as_connection.batch_read(keys, policy=self.policy)
+        self.as_connection.batch_read(self.keys, policy=self.policy)
         time.sleep(self.delay)
-        self.as_connection.get(KEY)
+        self.as_connection.get(self.keys[0])
 
     def test_batch_write(self):
         if (TestBaseClass.major_ver, TestBaseClass.minor_ver) < (7, 1):
@@ -169,7 +166,7 @@ class TestReadTouchTTLPercent:
         batch_records = br.BatchRecords(
             [
                 br.Read(
-                    key=KEY,
+                    key=self.keys[0],
                     ops=[
                         operations.read("a"),
                     ],
@@ -180,4 +177,4 @@ class TestReadTouchTTLPercent:
         time.sleep(self.delay)
         self.as_connection.batch_write(batch_records)
         time.sleep(self.delay)
-        self.as_connection.get(KEY)
+        self.as_connection.get(self.keys[0])

--- a/test/new_tests/test_command_level_policies.py
+++ b/test/new_tests/test_command_level_policies.py
@@ -88,26 +88,26 @@ class CommandLevelTTL:
         verify_record_ttl(self.client, KEY, expected_ttl=self.NEW_TTL)
 
 
-TTL = 2
-
-@pytest.mark.parametrize(
-    "insert_records",
-    [{"record_count": 1, "make_set_unique": True, "batch_write_command_policy": {"ttl": TTL}}],
-    indirect=True
-)
-@pytest.mark.usefixtures("insert_records")
 class TestReadTouchTTLPercent:
     @pytest.fixture(autouse=True)
     def setup(self, as_connection):
+        ttl = 2
+        self.as_connection.put(KEY, bins={"a": 1}, policy={"ttl": ttl})
         self.policy = {
             "read_touch_ttl_percent": 50
         }
         self.invalid_policy = {
             "read_touch_ttl_percent": "1"
         }
-        self.delay = TTL / 2 + 0.1
+        self.delay = ttl / 2 + 0.1
 
         yield
+
+        # Some tests call the client remove API
+        try:
+            self.as_connection.remove(KEY)
+        except e.RecordNotFound:
+            pass
 
     def test_read_invalid(self):
         with pytest.raises(e.ParamError) as excinfo:
@@ -136,10 +136,10 @@ class TestReadTouchTTLPercent:
         time.sleep(self.delay)
         # By this time, the record's ttl should be less than 1 second left
         # Reset record TTL
-        self.as_connection.get(self.keys[0], policy=self.policy)
+        self.as_connection.get(KEY, policy=self.policy)
         time.sleep(self.delay)
         # Record should not have expired
-        self.as_connection.get(self.keys[0])
+        self.as_connection.get(KEY)
 
     def test_operate(self):
         if (TestBaseClass.major_ver, TestBaseClass.minor_ver) < (7, 1):
@@ -148,17 +148,20 @@ class TestReadTouchTTLPercent:
         ops = [
             operations.read("a")
         ]
-        self.as_connection.operate(self.keys[0], ops, policy=self.policy)
+        self.as_connection.operate(KEY, ops, policy=self.policy)
         time.sleep(self.delay)
-        self.as_connection.get(self.keys[0])
+        self.as_connection.get(KEY)
 
     def test_batch(self):
         if (TestBaseClass.major_ver, TestBaseClass.minor_ver) < (7, 1):
             pytest.skip(SKIP_MSG)
         time.sleep(self.delay)
-        self.as_connection.batch_read(self.keys, policy=self.policy)
+        keys = [
+            KEY
+        ]
+        self.as_connection.batch_read(keys, policy=self.policy)
         time.sleep(self.delay)
-        self.as_connection.get(self.keys[0])
+        self.as_connection.get(KEY)
 
     def test_batch_write(self):
         if (TestBaseClass.major_ver, TestBaseClass.minor_ver) < (7, 1):
@@ -166,7 +169,7 @@ class TestReadTouchTTLPercent:
         batch_records = br.BatchRecords(
             [
                 br.Read(
-                    key=self.keys[0],
+                    key=KEY,
                     ops=[
                         operations.read("a"),
                     ],
@@ -177,4 +180,4 @@ class TestReadTouchTTLPercent:
         time.sleep(self.delay)
         self.as_connection.batch_write(batch_records)
         time.sleep(self.delay)
-        self.as_connection.get(self.keys[0])
+        self.as_connection.get(KEY)

--- a/test/new_tests/test_exception_subcode.py
+++ b/test/new_tests/test_exception_subcode.py
@@ -1,5 +1,5 @@
 import pytest
-from .conftest import TEST_NS, TEST_SET, BIN_NAME, DYN_CONFIG_PATH
+from .conftest import TEST_NS, TEST_SET, BIN_NAME, DYN_CONFIG_PATH, KeysValue
 import aerospike
 from aerospike import exception as e
 from aerospike_helpers.operations import list_operations as list_ops, operations
@@ -9,116 +9,117 @@ from .test_base_class import TestBaseClass
 from . import as_errors
 
 
-KEY = (TEST_NS, TEST_SET, 1)
-KEY2 = (TEST_NS, TEST_SET, 2)
 OPS = [
     list_ops.list_get_by_index(BIN_NAME, index=99, return_type=aerospike.LIST_RETURN_VALUE)
 ]
 ERROR_DETAIL_VERBOSITY_SETTING = "error_detail_verbosity"
 
 
+@pytest.mark.parametrize(
+    "constant",
+    [
+        aerospike.SUB_PARAM_TTL_INVALID,
+        aerospike.SUB_PARAM_BITS_OFFSET_OUT_OF_RANGE,
+        aerospike.SUB_PARAM_BITS_SIZE_OUT_OF_RANGE,
+        aerospike.SUB_PARAM_BITS_RESIZE_EXCEEDED,
+        aerospike.SUB_PARAM_BIN_COUNT_TOO_LARGE,
+        aerospike.SUB_PARAM_STRING_CTX_MALFORMED,
+        aerospike.SUB_UNAVAIL_INITIAL_BALANCE_UNRESOLVED,
+        aerospike.SUB_UNAVAIL_REPLICA_UNAVAILABLE,
+        aerospike.SUB_UNSUPP_FEAT_MRT_REQUIRES_STRONG_CONSISTENCY,
+        aerospike.SUB_UNSUPP_FEAT_GENERIC,
+        aerospike.SUB_BIN_NOT_FOUND_HLL_CANNOT_CREATE_WITH_OP,
+        aerospike.SUB_BIN_NAME_COUNT_TOO_LARGE,
+        aerospike.SUB_FORBID_XDR_FILTER_BLOCKED,
+        aerospike.SUB_FORBID_SET_COUNT_STOP_WRITES,
+        aerospike.SUB_FORBID_SET_SIZE_STOP_WRITES,
+        aerospike.SUB_FORBID_CLOCK_SKEW_STOP_WRITES,
+        aerospike.SUB_FORBID_REPLACE_CONFLICT_RESOLVING,
+        aerospike.SUB_FORBID_TRUNCATED,
+        aerospike.SUB_FORBID_MASKING_POLICY_BLOCKED,
+        aerospike.SUB_FORBID_DURABILITY_VIOLATION,
+        aerospike.SUB_FORBID_MASKING_ROLE_VIOLATION,
+        aerospike.SUB_OPNOT_CDT_INDEX_OUT_OF_BOUNDS,
+        aerospike.SUB_OPNOT_CDT_RANK_OUT_OF_BOUNDS,
+        aerospike.SUB_OPNOT_CDT_BOUNDED_LIST_OVERFLOW,
+        aerospike.SUB_OPNOT_HLL_INDEX_BITS_UNSET,
+        aerospike.SUB_OPNOT_HLL_CANNOT_REDUCE_INDEX_BITS,
+        aerospike.SUB_OPNOT_HLL_CANNOT_REDUCE_MINHASH_BITS,
+        aerospike.SUB_OPNOT_HLL_CANNOT_FOLD_MINHASH,
+        aerospike.SUB_OPNOT_HLL_FOLD_INDEX_BITS_TOO_LARGE,
+        aerospike.SUB_OPNOT_HLL_INTERSECT_MINHASH_MISMATCH,
+        aerospike.SUB_OPNOT_STRING_CONVERSION_FAILED,
+        aerospike.SUB_OPNOT_STRING_UTF8_INVALID,
+        aerospike.SUB_OPNOT_STRING_REGEX_LIMIT_EXCEEDED,
+        aerospike.SUB_OPNOT_STRING_B64_INVALID
+    ]
+)
+def test_subcode_constants(constant):
+    assert type(constant) == int
+
+def assert_subcode(subcode: int, verbosity_level: int):
+    server_version = (TestBaseClass.major_ver, TestBaseClass.minor_ver, TestBaseClass.patch_ver)
+    if server_version < (8, 1, 3) or verbosity_level == aerospike.ERROR_DETAIL_NONE:
+        assert subcode == 0
+    else:
+        assert subcode > 0
+
+@pytest.mark.parametrize(
+    "insert_records",
+    [{"record_count": 2, "make_set_unique": False, "bins": {BIN_NAME: []}}],
+    indirect=True
+)
+@pytest.mark.usefixtures("insert_records")
 class TestExceptionSubcode:
+    verbosity_levels = [
+        aerospike.ERROR_DETAIL_NONE,
+        aerospike.ERROR_DETAIL_SUBCODE,
+        aerospike.ERROR_DETAIL_MESSAGE,
+        aerospike.ERROR_DETAIL_EXP_TRACE,
+    ]
+
     @pytest.mark.parametrize(
-        "constant",
+        "as_connection",
         [
-            aerospike.SUB_PARAM_TTL_INVALID,
-            aerospike.SUB_PARAM_BITS_OFFSET_OUT_OF_RANGE,
-            aerospike.SUB_PARAM_BITS_SIZE_OUT_OF_RANGE,
-            aerospike.SUB_PARAM_BITS_RESIZE_EXCEEDED,
-            aerospike.SUB_PARAM_BIN_COUNT_TOO_LARGE,
-            aerospike.SUB_PARAM_STRING_CTX_MALFORMED,
-            aerospike.SUB_UNAVAIL_INITIAL_BALANCE_UNRESOLVED,
-            aerospike.SUB_UNAVAIL_REPLICA_UNAVAILABLE,
-            aerospike.SUB_UNSUPP_FEAT_MRT_REQUIRES_STRONG_CONSISTENCY,
-            aerospike.SUB_UNSUPP_FEAT_GENERIC,
-            aerospike.SUB_BIN_NOT_FOUND_HLL_CANNOT_CREATE_WITH_OP,
-            aerospike.SUB_BIN_NAME_COUNT_TOO_LARGE,
-            aerospike.SUB_FORBID_XDR_FILTER_BLOCKED,
-            aerospike.SUB_FORBID_SET_COUNT_STOP_WRITES,
-            aerospike.SUB_FORBID_SET_SIZE_STOP_WRITES,
-            aerospike.SUB_FORBID_CLOCK_SKEW_STOP_WRITES,
-            aerospike.SUB_FORBID_REPLACE_CONFLICT_RESOLVING,
-            aerospike.SUB_FORBID_TRUNCATED,
-            aerospike.SUB_FORBID_MASKING_POLICY_BLOCKED,
-            aerospike.SUB_FORBID_DURABILITY_VIOLATION,
-            aerospike.SUB_FORBID_MASKING_ROLE_VIOLATION,
-            aerospike.SUB_OPNOT_CDT_INDEX_OUT_OF_BOUNDS,
-            aerospike.SUB_OPNOT_CDT_RANK_OUT_OF_BOUNDS,
-            aerospike.SUB_OPNOT_CDT_BOUNDED_LIST_OVERFLOW,
-            aerospike.SUB_OPNOT_HLL_INDEX_BITS_UNSET,
-            aerospike.SUB_OPNOT_HLL_CANNOT_REDUCE_INDEX_BITS,
-            aerospike.SUB_OPNOT_HLL_CANNOT_REDUCE_MINHASH_BITS,
-            aerospike.SUB_OPNOT_HLL_CANNOT_FOLD_MINHASH,
-            aerospike.SUB_OPNOT_HLL_FOLD_INDEX_BITS_TOO_LARGE,
-            aerospike.SUB_OPNOT_HLL_INTERSECT_MINHASH_MISMATCH,
-            aerospike.SUB_OPNOT_STRING_CONVERSION_FAILED,
-            aerospike.SUB_OPNOT_STRING_UTF8_INVALID,
-            aerospike.SUB_OPNOT_STRING_REGEX_LIMIT_EXCEEDED,
-            aerospike.SUB_OPNOT_STRING_B64_INVALID
-        ]
+            KeysValue(["policies", "operate", ERROR_DETAIL_VERBOSITY_SETTING], verbosity_level)
+            for verbosity_level in verbosity_levels
+        ],
+        indirect=True
     )
-    def test_subcode_constants(self, constant):
-        assert type(constant) == int
-
-    # TODO: need to reuse fixture in conftest.py using indirect params to set num of records
-    @pytest.fixture()
-    def setup(self, as_connection):
-        self.as_connection.put(KEY, bins={BIN_NAME: []})
-        self.as_connection.put(KEY2, bins={BIN_NAME: []})
-        yield
-        self.as_connection.batch_remove(keys=[KEY, KEY2])
-
-    @pytest.mark.parametrize(
-        "policy_w_verbosity_setting",
-        [
-            {ERROR_DETAIL_VERBOSITY_SETTING: aerospike.ERROR_DETAIL_NONE},
-            {ERROR_DETAIL_VERBOSITY_SETTING: aerospike.ERROR_DETAIL_SUBCODE},
-            {ERROR_DETAIL_VERBOSITY_SETTING: aerospike.ERROR_DETAIL_MESSAGE},
-        ]
-    )
-    @pytest.mark.parametrize(
-        "set_in_client_config",
-        [False, True]
-    )
-    @pytest.mark.usefixtures("setup")
-    def test_error_verbosity_levels(self, policy_w_verbosity_setting: dict, set_in_client_config: bool):
-        if set_in_client_config:
-            config = {
-                "policies": {
-                    "operate": policy_w_verbosity_setting
-                }
-            }
-            self.as_connection = TestBaseClass.get_new_connection(config)
-
+    def test_error_verbosity_levels_from_client_config(self):
         with pytest.raises(e.OpNotApplicable) as excinfo:
-            cmd_policy = {}
-            if not set_in_client_config:
-                cmd_policy |= policy_w_verbosity_setting
-
-            self.as_connection.operate(KEY, OPS, policy=cmd_policy)
+            self.as_connection.operate(self.keys[0], OPS)
 
         # Make sure there's no regression with the parent error code
         assert excinfo.value.code == as_errors.AEROSPIKE_ERR_OP_NOT_APPLICABLE
 
-        subcode_should_be_zero = (
-            ERROR_DETAIL_VERBOSITY_SETTING not in policy_w_verbosity_setting
-            or
-            policy_w_verbosity_setting[ERROR_DETAIL_VERBOSITY_SETTING] == aerospike.ERROR_DETAIL_NONE
-            or
-            # If running against a unsupported version, we expect subcode to always return 0
-            # (and no undefined behavior)
-            (TestBaseClass.major_ver, TestBaseClass.minor_ver, TestBaseClass.patch_ver) < (8, 1, 3)
-        )
-        if subcode_should_be_zero:
-            assert excinfo.value.subcode == 0
-        else:
-            assert excinfo.value.subcode > 0
+        policies = self.as_connection.get_policies()
+        assert_subcode(excinfo.value.subcode, policies["operate"][ERROR_DETAIL_VERBOSITY_SETTING])
 
-    @pytest.mark.usefixtures("setup")
+    @pytest.mark.parametrize(
+        "as_connection",
+        [
+            KeysValue(["policies", "operate", ERROR_DETAIL_VERBOSITY_SETTING], aerospike.ERROR_DETAIL_NONE)
+        ],
+        indirect=True
+    )
+    @pytest.mark.parametrize(
+        "verbosity_level",
+        verbosity_levels
+    )
+    def test_error_verbosity_levels_from_command_policy(self, verbosity_level):
+        with pytest.raises(e.OpNotApplicable) as excinfo:
+            self.as_connection.operate(self.keys[0], OPS, policy={ERROR_DETAIL_VERBOSITY_SETTING: verbosity_level})
+
+        # Make sure there's no regression with the parent error code
+        assert excinfo.value.code == as_errors.AEROSPIKE_ERR_OP_NOT_APPLICABLE
+
+        assert_subcode(excinfo.value.subcode, verbosity_level)
+
     def test_batch_record_message_field_is_none_when_batch_succeeds(self):
         brs = BatchRecords(
             [
-                Read(KEY, ops=[
+                Read(self.keys[0], ops=[
                     operations.read(BIN_NAME)
                 ])
             ]
@@ -128,51 +129,25 @@ class TestExceptionSubcode:
             assert br.message is None
             assert br.subcode == 0
 
-    @pytest.mark.usefixtures("setup")
-    @pytest.mark.parametrize(
-        "brs",
-        [
-            [
-                Read(KEY, ops=OPS),
-            ],
-            [
-                Read(KEY, ops=OPS),
-                Read(KEY2, ops=OPS),
-            ]
-        ]
-    )
-    def test_batch_write_return_error_details(self, brs):
+    @pytest.mark.parametrize("key_count", [1, 2])
+    def test_batch_write_return_error_details(self, key_count):
         brs = BatchRecords(
-            brs
+            [Read(key, ops=OPS) for key in self.keys[:key_count]]
         )
         self.as_connection.batch_write(brs, policy_batch={ERROR_DETAIL_VERBOSITY_SETTING: aerospike.ERROR_DETAIL_MESSAGE})
         for br in brs.batch_records:
             assert isinstance(br.message, str)
-            if (TestBaseClass.major_ver, TestBaseClass.minor_ver, TestBaseClass.patch_ver) < (8, 1, 3):
-                assert br.subcode == 0
-            else:
-                assert br.subcode > 0
+            assert_subcode(br.subcode, aerospike.ERROR_DETAIL_MESSAGE)
 
-    @pytest.mark.usefixtures("setup")
-    @pytest.mark.parametrize(
-        "keys",
-        [
-            [KEY],
-            [KEY, KEY2]
-        ]
-    )
-    def test_batch_operate_return_error_details(self, keys):
+    @pytest.mark.parametrize("key_count", [1, 2])
+    def test_batch_operate_return_error_details(self, key_count):
         brs = self.as_connection.batch_operate(
-            keys, OPS, policy_batch={ERROR_DETAIL_VERBOSITY_SETTING: aerospike.ERROR_DETAIL_MESSAGE})
+            self.keys[:key_count], OPS, policy_batch={ERROR_DETAIL_VERBOSITY_SETTING: aerospike.ERROR_DETAIL_MESSAGE})
 
         for br in brs.batch_records:
             assert isinstance(br.message, str)
-            if (TestBaseClass.major_ver, TestBaseClass.minor_ver, TestBaseClass.patch_ver) < (8, 1, 3):
-                assert br.subcode == 0
-            else:
-                assert br.subcode > 0
+            assert_subcode(br.subcode, aerospike.ERROR_DETAIL_MESSAGE)
 
-    @pytest.mark.usefixtures("setup")
     @pytest.mark.parametrize(
         "verbosity_level",
         [
@@ -190,7 +165,7 @@ class TestExceptionSubcode:
             "expressions": expr.GE(expr.Abs(expr.Val("a")), 1).compile()
         }
         with pytest.raises(e.InvalidRequest) as excinfo:
-            self.as_connection.get(KEY, policy=policy)
+            self.as_connection.get(self.keys[0], policy=policy)
 
         assert "; exp_trace={" in excinfo.value.msg
         print(excinfo.value.msg)
@@ -200,15 +175,14 @@ class TestExceptionSubcode:
         [
             (
                 aerospike.Client.get,
-                {"key": KEY}
+                {}
             ),
             (
                 aerospike.Client.put,
-                {"key": KEY, "bins": {"a": 1}}
+                {"bins": {"a": 1}}
             )
         ]
     )
-    @pytest.mark.usefixtures("setup")
     def test_dyn_config(self, api_method, kwargs):
         if (TestBaseClass.major_ver, TestBaseClass.minor_ver, TestBaseClass.patch_ver) < (8, 1, 3):
             pytest.skip("Expression tracing only supported in server 8.1.3 or higher")
@@ -223,7 +197,7 @@ class TestExceptionSubcode:
             "expressions": expr.GE(expr.Abs(expr.Val("a")), 1).compile()
         }
         with pytest.raises(e.InvalidRequest) as excinfo:
-            api_method(client, **kwargs, policy=policy)
+            api_method(client, key=self.keys[0], **kwargs, policy=policy)
 
         assert "; exp_trace={" in excinfo.value.msg
         print(excinfo.value.msg)

--- a/test/new_tests/test_exception_subcode.py
+++ b/test/new_tests/test_exception_subcode.py
@@ -129,6 +129,9 @@ class TestExceptionSubcode:
             assert br.message is None
             assert br.subcode == 0
 
+    # For the following two tests, we test both the single record batch optimization path
+    # as well as the regular batch codepath
+
     @pytest.mark.parametrize("key_count", [1, 2])
     def test_batch_write_return_error_details(self, key_count):
         brs = BatchRecords(

--- a/test/new_tests/test_exception_subcode.py
+++ b/test/new_tests/test_exception_subcode.py
@@ -1,5 +1,5 @@
 import pytest
-from .conftest import TEST_NS, TEST_SET, BIN_NAME, DYN_CONFIG_PATH, KeysValue
+from .conftest import TEST_NS, TEST_SET, BIN_NAME, DYN_CONFIG_PATH, ClientConfigKeysValue
 import aerospike
 from aerospike import exception as e
 from aerospike_helpers.operations import list_operations as list_ops, operations
@@ -81,7 +81,7 @@ class TestExceptionSubcode:
     @pytest.mark.parametrize(
         "as_connection",
         [
-            KeysValue(["policies", "operate", ERROR_DETAIL_VERBOSITY_SETTING], verbosity_level)
+            ClientConfigKeysValue(["policies", "operate", ERROR_DETAIL_VERBOSITY_SETTING], verbosity_level)
             for verbosity_level in verbosity_levels
         ],
         indirect=True
@@ -99,7 +99,7 @@ class TestExceptionSubcode:
     @pytest.mark.parametrize(
         "as_connection",
         [
-            KeysValue(["policies", "operate", ERROR_DETAIL_VERBOSITY_SETTING], aerospike.ERROR_DETAIL_NONE)
+            ClientConfigKeysValue(["policies", "operate", ERROR_DETAIL_VERBOSITY_SETTING], aerospike.ERROR_DETAIL_NONE)
         ],
         indirect=True
     )

--- a/test/new_tests/test_exception_subcode.py
+++ b/test/new_tests/test_exception_subcode.py
@@ -71,7 +71,6 @@ class TestExceptionSubcode:
     @pytest.mark.parametrize(
         "policy_w_verbosity_setting",
         [
-            {},
             {ERROR_DETAIL_VERBOSITY_SETTING: aerospike.ERROR_DETAIL_NONE},
             {ERROR_DETAIL_VERBOSITY_SETTING: aerospike.ERROR_DETAIL_SUBCODE},
             {ERROR_DETAIL_VERBOSITY_SETTING: aerospike.ERROR_DETAIL_MESSAGE},

--- a/test/new_tests/test_get_put.py
+++ b/test/new_tests/test_get_put.py
@@ -726,7 +726,6 @@ class TestGetPut:
         with pytest.raises(e.RecordGenerationError) as excinfo:
             self.as_connection.put(key, rec, meta, policy)
         assert excinfo.value.code == 3
-        assert "AEROSPIKE_ERR_RECORD_GENERATION" in excinfo.value.msg
 
         (key, meta, bins) = self.as_connection.get(key)
         assert {"name": "John"} == bins

--- a/test/new_tests/test_get_put.py
+++ b/test/new_tests/test_get_put.py
@@ -727,6 +727,9 @@ class TestGetPut:
             self.as_connection.put(key, rec, meta, policy)
         assert excinfo.value.code == 3
 
+        if (TestBaseClass.major_ver, TestBaseClass.minor_ver, TestBaseClass.patch_ver) < (8, 1, 3):
+            assert "AEROSPIKE_ERR_RECORD_GENERATION" in excinfo.value.msg
+
         (key, meta, bins) = self.as_connection.get(key)
         assert {"name": "John"} == bins
         self.as_connection.remove(key)

--- a/test/new_tests/test_get_udf.py
+++ b/test/new_tests/test_get_udf.py
@@ -7,7 +7,13 @@ from aerospike import exception as e
 
 import aerospike
 
-
+@pytest.mark.parametrize(
+    "connection_with_udf",
+    [
+        "bin_lua.lua"
+    ],
+    indirect=True
+)
 @pytest.mark.usefixtures("connection_with_udf")
 class TestGetRegistered(object):
     def setup_class(cls):
@@ -15,10 +21,9 @@ class TestGetRegistered(object):
         Set the name of the UDF to load
         store the contents of the file for future comparison
         """
-        cls.udf_to_load = "bin_lua.lua"
         cls.loaded_udf_name = "bin_lua.lua"
         cls.udf_language = aerospike.UDF_TYPE_LUA
-        with open(cls.udf_to_load, "r", newline='') as udf_file:
+        with open(cls.loaded_udf_name, "r", newline='') as udf_file:
             cls.loaded_udf_content = udf_file.read()
 
     def test_udf_get_with_correct_paramters_no_policy(self):

--- a/test/new_tests/test_get_udf.py
+++ b/test/new_tests/test_get_udf.py
@@ -7,13 +7,7 @@ from aerospike import exception as e
 
 import aerospike
 
-@pytest.mark.parametrize(
-    "connection_with_udf",
-    [
-        "bin_lua.lua"
-    ],
-    indirect=True
-)
+
 @pytest.mark.usefixtures("connection_with_udf")
 class TestGetRegistered(object):
     def setup_class(cls):
@@ -21,9 +15,10 @@ class TestGetRegistered(object):
         Set the name of the UDF to load
         store the contents of the file for future comparison
         """
+        cls.udf_to_load = "bin_lua.lua"
         cls.loaded_udf_name = "bin_lua.lua"
         cls.udf_language = aerospike.UDF_TYPE_LUA
-        with open(cls.loaded_udf_name, "r", newline='') as udf_file:
+        with open(cls.udf_to_load, "r", newline='') as udf_file:
             cls.loaded_udf_content = udf_file.read()
 
     def test_udf_get_with_correct_paramters_no_policy(self):

--- a/test/new_tests/test_query_bin_projection.py
+++ b/test/new_tests/test_query_bin_projection.py
@@ -20,7 +20,9 @@ class TestQueryBinProjection:
         ),
         pytest.mark.parametrize(
             "insert_records",
-            [{"record_count": 500, "make_set_unique": False}],
+            [
+                [500, False]
+            ],
             indirect=True
         )
     ]

--- a/test/new_tests/test_query_bin_projection.py
+++ b/test/new_tests/test_query_bin_projection.py
@@ -20,9 +20,7 @@ class TestQueryBinProjection:
         ),
         pytest.mark.parametrize(
             "insert_records",
-            [
-                [500, False]
-            ],
+            [{"record_count": 500, "make_set_unique": False}],
             indirect=True
         )
     ]

--- a/test/new_tests/test_query_execute_background.py
+++ b/test/new_tests/test_query_execute_background.py
@@ -43,7 +43,7 @@ def validate_records(client, keys, validator):
 
 @pytest.mark.parametrize(
     "insert_records",
-    [[500, False]],
+    [{"record_count": 500, "make_set_unique": False}],
     indirect=True
 )
 class TestQueryApply(object):

--- a/test/new_tests/test_query_execute_background.py
+++ b/test/new_tests/test_query_execute_background.py
@@ -43,7 +43,7 @@ def validate_records(client, keys, validator):
 
 @pytest.mark.parametrize(
     "insert_records",
-    [{"record_count": 500, "make_set_unique": False}],
+    [[500, False]],
     indirect=True
 )
 class TestQueryApply(object):

--- a/test/new_tests/test_scan_apply.py
+++ b/test/new_tests/test_scan_apply.py
@@ -9,9 +9,15 @@ from .conftest import wait_for_job_completion
 import aerospike
 
 
+@pytest.mark.parametrize(
+    "connection_with_udf",
+    [
+        "bin_lua.lua"
+    ],
+    indirect=True
+)
 class TestScanApply(object):
     def setup_class(cls):
-        cls.udf_to_load = "bin_lua.lua"
         cls.loaded_udf_name = "bin_lua.lua"
         cls.udf_language = aerospike.UDF_TYPE_LUA
 

--- a/test/new_tests/test_scan_apply.py
+++ b/test/new_tests/test_scan_apply.py
@@ -9,15 +9,9 @@ from .conftest import wait_for_job_completion
 import aerospike
 
 
-@pytest.mark.parametrize(
-    "connection_with_udf",
-    [
-        "bin_lua.lua"
-    ],
-    indirect=True
-)
 class TestScanApply(object):
     def setup_class(cls):
+        cls.udf_to_load = "bin_lua.lua"
         cls.loaded_udf_name = "bin_lua.lua"
         cls.udf_language = aerospike.UDF_TYPE_LUA
 

--- a/test/new_tests/test_send_key_union_precedence.py
+++ b/test/new_tests/test_send_key_union_precedence.py
@@ -8,7 +8,7 @@ import os
 
 @pytest.mark.parametrize(
     "insert_records",
-    [{"record_count": 1, "make_set_unique": True}],
+    [[1, True]],
     indirect=True
 )
 @pytest.mark.usefixtures("insert_records")
@@ -46,16 +46,9 @@ class TestSendKeyUnionPrecedence:
 
         expect_records_to_have_user_key_stored(client, self.set_name)
 
-    udf_to_load = pytest.mark.parametrize(
-        "connection_with_udf",
-        [
-            "query_apply.lua"
-        ],
-        indirect=True
-    )
+    udf_to_load = "query_apply.lua"
 
     @pytest.mark.parametrize("set_key_option", [("apply", False)], indirect=True)
-    @udf_to_load
     def test_client_config_overrides_command_level_apply_policy(self, connection_with_udf):
         client = aerospike.client(self.config)
 
@@ -75,7 +68,6 @@ class TestSendKeyUnionPrecedence:
         expect_records_to_have_user_key_stored(client, self.set_name)
 
     @pytest.mark.parametrize("set_key_option", [("batch_apply", False)], indirect=True)
-    @udf_to_load
     def test_client_config_overrides_command_level_batch_apply_policy(self, connection_with_udf):
         client = aerospike.client(self.config)
 

--- a/test/new_tests/test_send_key_union_precedence.py
+++ b/test/new_tests/test_send_key_union_precedence.py
@@ -8,7 +8,7 @@ import os
 
 @pytest.mark.parametrize(
     "insert_records",
-    [[1, True]],
+    [{"record_count": 1, "make_set_unique": True}],
     indirect=True
 )
 @pytest.mark.usefixtures("insert_records")
@@ -46,9 +46,16 @@ class TestSendKeyUnionPrecedence:
 
         expect_records_to_have_user_key_stored(client, self.set_name)
 
-    udf_to_load = "query_apply.lua"
+    udf_to_load = pytest.mark.parametrize(
+        "connection_with_udf",
+        [
+            "query_apply.lua"
+        ],
+        indirect=True
+    )
 
     @pytest.mark.parametrize("set_key_option", [("apply", False)], indirect=True)
+    @udf_to_load
     def test_client_config_overrides_command_level_apply_policy(self, connection_with_udf):
         client = aerospike.client(self.config)
 
@@ -68,6 +75,7 @@ class TestSendKeyUnionPrecedence:
         expect_records_to_have_user_key_stored(client, self.set_name)
 
     @pytest.mark.parametrize("set_key_option", [("batch_apply", False)], indirect=True)
+    @udf_to_load
     def test_client_config_overrides_command_level_batch_apply_policy(self, connection_with_udf):
         client = aerospike.client(self.config)
 

--- a/test/new_tests/test_string_operations.py
+++ b/test/new_tests/test_string_operations.py
@@ -559,6 +559,25 @@ class TestStringOperations:
     )
 
     @nfc_param
+    @pytest.mark.parametrize(
+        "op, expected_result",
+        [
+            (str_ops.find, 0),
+            (str_ops.contains, True)
+        ]
+    )
+    def test_read_across_normalization_forms(self, op, expected_result, bin_substr, str_param):
+        BIN_NAME = "str"
+        self.as_connection.put(KEY, bins={BIN_NAME: bin_substr})
+
+        ops = [
+            op(bin_name=BIN_NAME, needle=str_param),
+        ]
+        with self.expected_context_for_pos_tests:
+            _, _, bins = self.as_connection.operate(KEY, ops)
+            assert bins[BIN_NAME] == expected_result
+
+    @nfc_param
     def test_replace_across_normalization_forms(self, bin_substr, str_param):
         STR_TO_REPL = bin_substr + " au lait"
         BIN_NAME = "str"

--- a/test/new_tests/test_udf_remove.py
+++ b/test/new_tests/test_udf_remove.py
@@ -110,19 +110,18 @@ class TestUdfRemove(object):
         assert not present
 
 
-@pytest.mark.parametrize(
-    "connection_with_udf",
-    [
-        "example.lua"
-    ],
-    indirect=True
-)
 @pytest.mark.usefixtures("connection_with_udf")
 class TestIncorrectCallsToUDFRemove(object):
     """
     These are all tests where udf_remove fails for various reasons,
     So we skip removing and re-adding the UDF before and after each test
     """
+
+    def setup_class(cls):
+        """
+        setup the class attribute indicating the udf to load
+        """
+        cls.udf_to_load = "example.lua"
 
     def test_udf_remove_with_proper_parameters_without_connection(self):
         """

--- a/test/new_tests/test_udf_remove.py
+++ b/test/new_tests/test_udf_remove.py
@@ -110,18 +110,19 @@ class TestUdfRemove(object):
         assert not present
 
 
+@pytest.mark.parametrize(
+    "connection_with_udf",
+    [
+        "example.lua"
+    ],
+    indirect=True
+)
 @pytest.mark.usefixtures("connection_with_udf")
 class TestIncorrectCallsToUDFRemove(object):
     """
     These are all tests where udf_remove fails for various reasons,
     So we skip removing and re-adding the UDF before and after each test
     """
-
-    def setup_class(cls):
-        """
-        setup the class attribute indicating the udf to load
-        """
-        cls.udf_to_load = "example.lua"
 
     def test_udf_remove_with_proper_parameters_without_connection(self):
         """


### PR DESCRIPTION
Hoping to review and merge by tomorrow

- Removed error verbosity test case that depends on client config policy's default value for `error_detail_verbosity` to be `NONE`.