### PR TITLE
[CLIENT-3994] Address test regressions on server 8.1.3 w/out refactor work

### DIFF
--- a/test/new_tests/string_helpers.py
+++ b/test/new_tests/string_helpers.py
@@ -5,6 +5,7 @@ from aerospike_helpers.string_helpers import StringPolicy
 
 NON_STR_BIN_NAME = INT_BIN_NAME = "nonstr"
 STR_BIN_NAME = "str"
+STR_BIN_NAME2 = "str2"
 DOUBLE_BIN_NAME = "double"
 BLOB_BIN_NAME = "blob"
 UPPERCASE_STR_BIN_NAME = "uppercase_str"
@@ -39,6 +40,7 @@ NEW_STR = "1234"
 
 BINS = {
     STR_BIN_NAME: EXAMPLE_STR,
+    STR_BIN_NAME2: "hello",
     INT_BIN_NAME: 1,
     UPPERCASE_STR_BIN_NAME: UPPERCASE_STR,
     NESTED_STR_BIN_NAME: [EXAMPLE_STR],

--- a/test/new_tests/test_base_class.py
+++ b/test/new_tests/test_base_class.py
@@ -240,7 +240,6 @@ class TestBaseClass(object):
             config["policies"][policy_name]["total_timeout"] = 180000
             # Must hear back from server after a certain number of seconds
             config["policies"][policy_name]["socket_timeout"] = 180000
-            config["policies"][policy_name]["error_detail_verbosity"] = aerospike.ERROR_DETAIL_EXP_TRACE
         # config["max_socket_idle"] = 60
 
         config["policies"]["info"] = {}

--- a/test/new_tests/test_exception_subcode.py
+++ b/test/new_tests/test_exception_subcode.py
@@ -71,7 +71,6 @@ class TestExceptionSubcode:
     @pytest.mark.parametrize(
         "policy_w_verbosity_setting",
         [
-            {},
             {ERROR_DETAIL_VERBOSITY_SETTING: aerospike.ERROR_DETAIL_NONE},
             {ERROR_DETAIL_VERBOSITY_SETTING: aerospike.ERROR_DETAIL_SUBCODE},
             {ERROR_DETAIL_VERBOSITY_SETTING: aerospike.ERROR_DETAIL_MESSAGE},

--- a/test/new_tests/test_exception_subcode.py
+++ b/test/new_tests/test_exception_subcode.py
@@ -71,6 +71,7 @@ class TestExceptionSubcode:
     @pytest.mark.parametrize(
         "policy_w_verbosity_setting",
         [
+            {},
             {ERROR_DETAIL_VERBOSITY_SETTING: aerospike.ERROR_DETAIL_NONE},
             {ERROR_DETAIL_VERBOSITY_SETTING: aerospike.ERROR_DETAIL_SUBCODE},
             {ERROR_DETAIL_VERBOSITY_SETTING: aerospike.ERROR_DETAIL_MESSAGE},

--- a/test/new_tests/test_get_put.py
+++ b/test/new_tests/test_get_put.py
@@ -726,7 +726,6 @@ class TestGetPut:
         with pytest.raises(e.RecordGenerationError) as excinfo:
             self.as_connection.put(key, rec, meta, policy)
         assert excinfo.value.code == 3
-        assert "AEROSPIKE_ERR_RECORD_GENERATION" in excinfo.value.msg
 
         (key, meta, bins) = self.as_connection.get(key)
         assert {"name": "John"} == bins

--- a/test/new_tests/test_get_put.py
+++ b/test/new_tests/test_get_put.py
@@ -727,6 +727,9 @@ class TestGetPut:
             self.as_connection.put(key, rec, meta, policy)
         assert excinfo.value.code == 3
 
+        if (TestBaseClass.major_ver, TestBaseClass.minor_ver, TestBaseClass.patch_ver) < (8, 1, 3):
+            assert "AEROSPIKE_ERR_RECORD_GENERATION" in excinfo.value.msg
+
         (key, meta, bins) = self.as_connection.get(key)
         assert {"name": "John"} == bins
         self.as_connection.remove(key)

--- a/test/new_tests/test_string_operations.py
+++ b/test/new_tests/test_string_operations.py
@@ -559,6 +559,25 @@ class TestStringOperations:
     )
 
     @nfc_param
+    @pytest.mark.parametrize(
+        "op, expected_result",
+        [
+            (str_ops.find, 0),
+            (str_ops.contains, True)
+        ]
+    )
+    def test_read_across_normalization_forms(self, op, expected_result, bin_substr, str_param):
+        BIN_NAME = "str"
+        self.as_connection.put(KEY, bins={BIN_NAME: bin_substr})
+
+        ops = [
+            op(bin_name=BIN_NAME, needle=str_param),
+        ]
+        with self.expected_context_for_pos_tests:
+            _, _, bins = self.as_connection.operate(KEY, ops)
+            assert bins[BIN_NAME] == expected_result
+
+    @nfc_param
     def test_replace_across_normalization_forms(self, bin_substr, str_param):
         STR_TO_REPL = bin_substr + " au lait"
         BIN_NAME = "str"

--- a/test/new_tests/test_string_operations.py
+++ b/test/new_tests/test_string_operations.py
@@ -603,10 +603,10 @@ class TestStringOperations:
     @pytest.mark.parametrize(
         "op",
         [
-            str_ops.repeat(STR_BIN_NAME, count=RESULT_SIZE_CAP),
-            str_ops.pad_start(STR_BIN_NAME, target_length=RESULT_SIZE_CAP, pad_string="*"),
-            str_ops.pad_end(STR_BIN_NAME, target_length=RESULT_SIZE_CAP, pad_string="*"),
-            str_ops.concat(STR_BIN_NAME, value_list=["*" * RESULT_SIZE_CAP]),
+            str_ops.repeat(STR_BIN_NAME2, count=RESULT_SIZE_CAP),
+            str_ops.pad_start(STR_BIN_NAME2, target_length=RESULT_SIZE_CAP // 4 + 1, pad_string="*"),
+            str_ops.pad_end(STR_BIN_NAME2, target_length=RESULT_SIZE_CAP // 4 + 1, pad_string="*"),
+            str_ops.concat(STR_BIN_NAME2, value_list=["x" * RESULT_SIZE_CAP]),
         ]
     )
     def test_result_size_cap(self, op):


### PR DESCRIPTION
Add tests that fail on server 8.1.3 RC3, but should now pass on RC4
Disables expression tracing as discussed with Shannon, since it isn't necessary to run the whole test suite and most of it doesn't check for enhanced error details, anyway.

## Notes

Avoids test refactor work to make reviewing faster