### PR TITLE
test: mark failing tests on 8.1.3 RC3 as xfail so we can provide QE with a release bundle sooner

### DIFF
--- a/test/new_tests/test_string_operations.py
+++ b/test/new_tests/test_string_operations.py
@@ -566,6 +566,7 @@ class TestStringOperations:
             (str_ops.contains, True)
         ]
     )
+    @pytest.mark.xfail("This currently fails on server 8.1.3 RC3. This should pass on RC4, and we can tell if the result is XPASS")
     def test_read_across_normalization_forms(self, op, expected_result, bin_substr, str_param):
         BIN_NAME = "str"
         self.as_connection.put(KEY, bins={BIN_NAME: bin_substr})

--- a/test/new_tests/test_string_operations.py
+++ b/test/new_tests/test_string_operations.py
@@ -566,7 +566,7 @@ class TestStringOperations:
             (str_ops.contains, True)
         ]
     )
-    @pytest.mark.xfail("This currently fails on server 8.1.3 RC3. This should pass on RC4, and we can tell if the result is XPASS")
+    @pytest.mark.xfail(reason="This currently fails on server 8.1.3 RC3. This should pass on RC4, and we can tell if the result is XPASS")
     def test_read_across_normalization_forms(self, op, expected_result, bin_substr, str_param):
         BIN_NAME = "str"
         self.as_connection.put(KEY, bins={BIN_NAME: bin_substr})


### PR DESCRIPTION
I discussed with Justin, and we decided that this is necessary to provide QE with a release bundle ASAP without being blocked on RC4 being released. We can also manually verify that these tests pass on RC4 using "xfail" instead of skipping the test