### PR TITLE
[CLIENT-3879]: add invalid policy warning

### DIFF
--- a/doc/aerospike.rst
+++ b/doc/aerospike.rst
@@ -515,6 +515,14 @@ Only the `hosts` key is required; the rest of the keys are optional.
                 Traceback (most recent call last):
                 aerospike.exception.ParamError: "key_policy" is an invalid policy dictionary key
 
+            .. note::
+                **Known exception:** :meth:`~aerospike.Client.remove_bin` raises
+                :py:class:`~aerospike.exception.ClientError` instead of
+                :py:class:`~aerospike.exception.ParamError` for an invalid policy
+                dictionary key. This is scheduled to be fixed in the next major
+                client release; see :meth:`~aerospike.Client.remove_bin` for
+                details.
+
         * **hosts** (:class:`list`)
             A list identifying a node (or multiple nodes) in the cluster. Each entry may be
             either a tuple or a string.

--- a/doc/client.rst
+++ b/doc/client.rst
@@ -493,6 +493,16 @@ Record Commands
 
         :raises: a subclass of :exc:`~aerospike.exception.AerospikeError`.
 
+        .. note::
+            **Known issue:** if the client config's ``validate_keys`` option is :py:obj:`True` and
+            *policy* contains an invalid dictionary key, this method raises
+            :py:class:`~aerospike.exception.ClientError` instead of the
+            :py:class:`~aerospike.exception.ParamError` that every other method raises in this
+            situation (see :func:`aerospike.client`'s ``validate_keys`` option). Changing this
+            outright would be a breaking change, so it is deferred to the next major client
+            release. A :exc:`DeprecationWarning` is raised in the meantime to warn ahead of that
+            change.
+
         .. testcode::
 
             # Insert record

--- a/src/include/client.h
+++ b/src/include/client.h
@@ -598,10 +598,10 @@ PyObject *AerospikeClient_Abort(AerospikeClient *self, PyObject *args,
     "In the next major client release, when this %s object is executed, a "    \
     "ParamError will be raised."
 
-// CLIENT-3879: remove_bin() raises ClientError instead of ParamError when
-// validate_keys is True and an invalid policy dictionary key is passed.
-// Fixing this outright would be a breaking change, so for now we keep the
-// existing (incorrect) behavior and just warn ahead of the next major release.
+// remove_bin() raises ClientError instead of ParamError when validate_keys
+// is True and an invalid policy dictionary key is passed. Fixing this
+// outright would be a breaking change, so for now we keep the existing
+// (incorrect) behavior and just warn ahead of the next major release.
 #define REMOVE_BIN_INVALID_POLICY_KEY_MESSAGE                                  \
     "remove_bin() raised a ClientError because the policy dictionary "         \
     "contained an invalid key. In the next major client release, a "           \

--- a/src/include/client.h
+++ b/src/include/client.h
@@ -597,3 +597,12 @@ PyObject *AerospikeClient_Abort(AerospikeClient *self, PyObject *args,
     "Operations and bin names are mutually exclusive."                         \
     "In the next major client release, when this %s object is executed, a "    \
     "ParamError will be raised."
+
+// CLIENT-3879: remove_bin() raises ClientError instead of ParamError when
+// validate_keys is True and an invalid policy dictionary key is passed.
+// Fixing this outright would be a breaking change, so for now we keep the
+// existing (incorrect) behavior and just warn ahead of the next major release.
+#define REMOVE_BIN_INVALID_POLICY_KEY_MESSAGE                                  \
+    "remove_bin() raised a ClientError because the policy dictionary "         \
+    "contained an invalid key. In the next major client release, a "           \
+    "ParamError will be raised instead."

--- a/src/main/client/remove_bin.c
+++ b/src/main/client/remove_bin.c
@@ -28,12 +28,12 @@
 #include "policy.h"
 
 /**
- * CLIENT-3879: an invalid policy dictionary key should raise ParamError, not
- * ClientError, which is what happens once pyobject_to_policy_write clobbers
- * the specific error it already set. Fixing that outright would be a
- * breaking change, so for now we only warn about the future behavior change
- * here, matching the exact condition pyobject_to_policy_write itself uses to
- * decide whether to run the invalid-key check.
+ * An invalid policy dictionary key should raise ParamError, not ClientError,
+ * which is what happens once pyobject_to_policy_write clobbers the specific
+ * error it already set. Fixing that outright would be a breaking change, so
+ * for now we only warn about the future behavior change here, matching the
+ * exact condition pyobject_to_policy_write itself uses to decide whether to
+ * run the invalid-key check.
  *
  * Returns true if the warning was promoted to a real exception (warnings as
  * errors), in which case the caller must bail out immediately without

--- a/src/main/client/remove_bin.c
+++ b/src/main/client/remove_bin.c
@@ -52,6 +52,7 @@ AerospikeClient_RemoveBin_Invoke(AerospikeClient *self, PyObject *py_key,
     as_policy_write *write_policy_p = NULL;
     as_key key;
     bool key_initialized = false;
+    bool warning_became_exception = false;
     as_record rec;
     char *binName = NULL;
     int count = 0;
@@ -71,6 +72,28 @@ AerospikeClient_RemoveBin_Invoke(AerospikeClient *self, PyObject *py_key,
         goto CLEANUP;
     }
     key_initialized = true;
+
+    // CLIENT-3879: an invalid policy dictionary key should raise ParamError,
+    // not ClientError, which is what happens below once pyobject_to_policy_write
+    // clobbers the specific error it already set. Fixing that outright would be
+    // a breaking change, so for now we only warn about the future behavior
+    // change here, matching the exact condition pyobject_to_policy_write itself
+    // uses to decide whether to run the invalid-key check.
+    if (py_policy && py_policy != Py_None && self->validate_keys) {
+        as_status key_check_retval = does_py_dict_contain_valid_keys(
+            err, py_policy, py_write_policy_valid_keys,
+            POLICY_DICTIONARY_ADJECTIVE_FOR_ERROR_MESSAGE);
+        if (key_check_retval == 0) {
+            int retval =
+                PyErr_WarnFormat(PyExc_DeprecationWarning, STACK_LEVEL,
+                                 REMOVE_BIN_INVALID_POLICY_KEY_MESSAGE);
+            if (retval == -1) {
+                warning_became_exception = true;
+                goto CLEANUP;
+            }
+        }
+        as_error_reset(err);
+    }
 
     // Convert python policy object to as_policy_write
     pyobject_to_policy_write(self, err, py_policy, &write_policy,
@@ -122,6 +145,10 @@ CLEANUP:
 
     if (key_initialized) {
         as_key_destroy(&key);
+    }
+
+    if (warning_became_exception) {
+        return NULL;
     }
 
     if (err->code != AEROSPIKE_OK) {

--- a/src/main/client/remove_bin.c
+++ b/src/main/client/remove_bin.c
@@ -28,6 +28,39 @@
 #include "policy.h"
 
 /**
+ * CLIENT-3879: an invalid policy dictionary key should raise ParamError, not
+ * ClientError, which is what happens once pyobject_to_policy_write clobbers
+ * the specific error it already set. Fixing that outright would be a
+ * breaking change, so for now we only warn about the future behavior change
+ * here, matching the exact condition pyobject_to_policy_write itself uses to
+ * decide whether to run the invalid-key check.
+ *
+ * Returns true if the warning was promoted to a real exception (warnings as
+ * errors), in which case the caller must bail out immediately without
+ * raising anything else.
+ */
+static bool warn_if_invalid_remove_bin_policy_key(AerospikeClient *self,
+                                                  as_error *err,
+                                                  PyObject *py_policy)
+{
+    if (!py_policy || py_policy == Py_None || !self->validate_keys) {
+        return false;
+    }
+
+    as_status retval = does_py_dict_contain_valid_keys(
+        err, py_policy, py_write_policy_valid_keys,
+        POLICY_DICTIONARY_ADJECTIVE_FOR_ERROR_MESSAGE);
+    as_error_reset(err);
+
+    if (retval != 0) {
+        return false;
+    }
+
+    return PyErr_WarnFormat(PyExc_DeprecationWarning, STACK_LEVEL,
+                            REMOVE_BIN_INVALID_POLICY_KEY_MESSAGE) == -1;
+}
+
+/**
  ******************************************************************************************************
  * Removes a bin from a record.
  *
@@ -73,26 +106,9 @@ AerospikeClient_RemoveBin_Invoke(AerospikeClient *self, PyObject *py_key,
     }
     key_initialized = true;
 
-    // CLIENT-3879: an invalid policy dictionary key should raise ParamError,
-    // not ClientError, which is what happens below once pyobject_to_policy_write
-    // clobbers the specific error it already set. Fixing that outright would be
-    // a breaking change, so for now we only warn about the future behavior
-    // change here, matching the exact condition pyobject_to_policy_write itself
-    // uses to decide whether to run the invalid-key check.
-    if (py_policy && py_policy != Py_None && self->validate_keys) {
-        as_status key_check_retval = does_py_dict_contain_valid_keys(
-            err, py_policy, py_write_policy_valid_keys,
-            POLICY_DICTIONARY_ADJECTIVE_FOR_ERROR_MESSAGE);
-        if (key_check_retval == 0) {
-            int retval =
-                PyErr_WarnFormat(PyExc_DeprecationWarning, STACK_LEVEL,
-                                 REMOVE_BIN_INVALID_POLICY_KEY_MESSAGE);
-            if (retval == -1) {
-                warning_became_exception = true;
-                goto CLEANUP;
-            }
-        }
-        as_error_reset(err);
+    if (warn_if_invalid_remove_bin_policy_key(self, err, py_policy)) {
+        warning_became_exception = true;
+        goto CLEANUP;
     }
 
     // Convert python policy object to as_policy_write

--- a/test/new_tests/test_remove_bin.py
+++ b/test/new_tests/test_remove_bin.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import pytest
 import warnings
+from contextlib import nullcontext
 
 from .test_base_class import TestBaseClass
 import aerospike
@@ -269,14 +270,23 @@ class TestRemovebin(object):
         """
         Invoke remove_bin() with incorrect policy
 
-        An invalid policy dictionary key should raise ParamError, but for now
-        still raises ClientError (to avoid a breaking change) and warns that
-        this will change in the next major release.
+        With validate_keys enabled, an invalid policy dictionary key should
+        raise ParamError, but for now still raises ClientError (to avoid a
+        breaking change) and warns that this will change in the next major
+        release. With validate_keys disabled, the invalid key is silently
+        ignored and the operation succeeds, matching every other API method.
         """
         key = ("test", "demo", 1)
         policy = {"time": 1001}
-        with pytest.warns(DeprecationWarning, match="ParamError will be raised instead"):
-            with pytest.raises((e.ClientError, e.RecordNotFound)):
+        if self.config["validate_keys"]:
+            warns_context = pytest.warns(DeprecationWarning, match="ParamError will be raised instead")
+            raises_context = pytest.raises((e.ClientError, e.RecordNotFound))
+        else:
+            warns_context = nullcontext()
+            raises_context = nullcontext()
+
+        with warns_context:
+            with raises_context:
                 self.as_connection.remove_bin(key, ["age"], {}, policy)
 
     def test_neg_remove_bin_with_no_parameters(self):
@@ -369,6 +379,9 @@ class TestRemovebin(object):
         ClientError to avoid a breaking change, and warns that this will
         change in the next major release.
         """
+        if not self.config["validate_keys"]:
+            pytest.skip("Only applicable when validate_keys is enabled")
+
         key = ("test", "demo", "remove_bin_invalid_policy_key")
         put_data(self.as_connection, key, {"age": 30})
 

--- a/test/new_tests/test_remove_bin.py
+++ b/test/new_tests/test_remove_bin.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import pytest
 import warnings
-from contextlib import nullcontext
 
 from .test_base_class import TestBaseClass
 import aerospike
@@ -274,20 +273,21 @@ class TestRemovebin(object):
         raise ParamError, but for now still raises ClientError (to avoid a
         breaking change) and warns that this will change in the next major
         release. With validate_keys disabled, the invalid key is silently
-        ignored and the operation succeeds, matching every other API method.
+        ignored, so the call falls through to the actual remove-bin
+        operation, which either succeeds or raises RecordNotFound depending
+        on whether the key already exists.
         """
         key = ("test", "demo", 1)
         policy = {"time": 1001}
         if self.config["validate_keys"]:
-            warns_context = pytest.warns(DeprecationWarning, match="ParamError will be raised instead")
-            raises_context = pytest.raises((e.ClientError, e.RecordNotFound))
+            with pytest.warns(DeprecationWarning, match="ParamError will be raised instead"):
+                with pytest.raises((e.ClientError, e.RecordNotFound)):
+                    self.as_connection.remove_bin(key, ["age"], {}, policy)
         else:
-            warns_context = nullcontext()
-            raises_context = nullcontext()
-
-        with warns_context:
-            with raises_context:
+            try:
                 self.as_connection.remove_bin(key, ["age"], {}, policy)
+            except e.RecordNotFound:
+                pass
 
     def test_neg_remove_bin_with_no_parameters(self):
         """

--- a/test/new_tests/test_remove_bin.py
+++ b/test/new_tests/test_remove_bin.py
@@ -269,9 +269,9 @@ class TestRemovebin(object):
         """
         Invoke remove_bin() with incorrect policy
 
-        CLIENT-3879: an invalid policy dictionary key should raise ParamError,
-        but for now still raises ClientError (to avoid a breaking change) and
-        warns that this will change in the next major release.
+        An invalid policy dictionary key should raise ParamError, but for now
+        still raises ClientError (to avoid a breaking change) and warns that
+        this will change in the next major release.
         """
         key = ("test", "demo", 1)
         policy = {"time": 1001}
@@ -364,10 +364,10 @@ class TestRemovebin(object):
 
     def test_neg_remove_bin_with_invalid_policy_key_warns(self, put_data):
         """
-        CLIENT-3879: remove_bin() should raise ParamError for an invalid policy
-        dictionary key (with validate_keys enabled), but for now it still
-        raises ClientError to avoid a breaking change, and warns that this
-        will change in the next major release.
+        remove_bin() should raise ParamError for an invalid policy dictionary
+        key (with validate_keys enabled), but for now it still raises
+        ClientError to avoid a breaking change, and warns that this will
+        change in the next major release.
         """
         key = ("test", "demo", "remove_bin_invalid_policy_key")
         put_data(self.as_connection, key, {"age": 30})
@@ -380,8 +380,8 @@ class TestRemovebin(object):
 
     def test_neg_remove_bin_with_incorrect_policy_value_does_not_warn(self):
         """
-        CLIENT-3879: an invalid policy *value* (as opposed to an invalid key)
-        is a different, unrelated failure mode and should not trigger the
+        An invalid policy *value* (as opposed to an invalid key) is a
+        different, unrelated failure mode and should not trigger the
         ParamError-in-the-future deprecation warning.
         """
         key = ("test", "demo", 1)

--- a/test/new_tests/test_remove_bin.py
+++ b/test/new_tests/test_remove_bin.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import pytest
+import warnings
 
 from .test_base_class import TestBaseClass
 import aerospike
@@ -267,11 +268,16 @@ class TestRemovebin(object):
     def test_neg_remove_bin_with_incorrect_policy(self):
         """
         Invoke remove_bin() with incorrect policy
+
+        CLIENT-3879: an invalid policy dictionary key should raise ParamError,
+        but for now still raises ClientError (to avoid a breaking change) and
+        warns that this will change in the next major release.
         """
         key = ("test", "demo", 1)
         policy = {"time": 1001}
-        with pytest.raises((e.ClientError, e.RecordNotFound)):
-            self.as_connection.remove_bin(key, ["age"], {}, policy)
+        with pytest.warns(DeprecationWarning, match="ParamError will be raised instead"):
+            with pytest.raises((e.ClientError, e.RecordNotFound)):
+                self.as_connection.remove_bin(key, ["age"], {}, policy)
 
     def test_neg_remove_bin_with_no_parameters(self):
         """
@@ -355,6 +361,35 @@ class TestRemovebin(object):
         with pytest.raises(e.ClientError) as exceptionInfo:
             self.as_connection.remove_bin(key, ["age"], {}, policy)
         assert exceptionInfo.value.code == -1
+
+    def test_neg_remove_bin_with_invalid_policy_key_warns(self, put_data):
+        """
+        CLIENT-3879: remove_bin() should raise ParamError for an invalid policy
+        dictionary key (with validate_keys enabled), but for now it still
+        raises ClientError to avoid a breaking change, and warns that this
+        will change in the next major release.
+        """
+        key = ("test", "demo", "remove_bin_invalid_policy_key")
+        put_data(self.as_connection, key, {"age": 30})
+
+        with pytest.warns(DeprecationWarning, match="ParamError will be raised instead") as warn_record:
+            with pytest.raises(e.ClientError) as exceptionInfo:
+                self.as_connection.remove_bin(key, ["age"], {}, {"not_a_real_key": 123})
+        assert exceptionInfo.value.code == -1
+        assert len(warn_record) == 1
+
+    def test_neg_remove_bin_with_incorrect_policy_value_does_not_warn(self):
+        """
+        CLIENT-3879: an invalid policy *value* (as opposed to an invalid key)
+        is a different, unrelated failure mode and should not trigger the
+        ParamError-in-the-future deprecation warning.
+        """
+        key = ("test", "demo", 1)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            with pytest.raises(e.ClientError):
+                self.as_connection.remove_bin(key, ["age"], {}, {"total_timeout": 0.5})
 
     @pytest.mark.parametrize(
         "key, bin_for_removal, ex_code",


### PR DESCRIPTION
Fixes: https://aerospike.atlassian.net/browse/CLIENT-3879

## Summary

`remove_bin()` raises `ClientError` instead of `ParamError` when `validate_keys` is enabled and the policy dict has an invalid key. Fixing that outright is a breaking change, so this only:
- Emits a `DeprecationWarning` warning that a future major release will raise `ParamError` instead
- Documents the discrepancy in `client.rst` / `aerospike.rst`

## Test plan
- [x] New/updated tests in `test_remove_bin.py` cover: warning fires on invalid key, warning does not fire on invalid value
