### PR TITLE
Update all references to server 8.1.3 with 8.2.0

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -268,7 +268,7 @@ jobs:
         num-nodes: 1
         oidc-provider: ${{ vars.OIDC_PROVIDER_NAME }}
         oidc-audience: ${{ vars.OIDC_AUDIENCE }}
-        server-tag: ${{ matrix.test == 'code-examples' && '8.1.3.0-35-20260629033923' || needs.get-env-vars.outputs.server-tag }}
+        server-tag: ${{ matrix.test == 'code-examples' && '8.8.2.0.0-20260908214755' || needs.get-env-vars.outputs.server-tag }}
         server-container-repo: database-docker-virtual/aerospike-server${{ matrix.test == 'ee-code-examples' && '-enterprise' || '' }}
         tools-tag: 13.0.2_1
         config-file: ${{ (matrix.test == 'doctest' || matrix.test == 'ce-code-examples') && './.github/workflows/aerospike-ce.conf' || '' }}

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -268,7 +268,7 @@ jobs:
         num-nodes: 1
         oidc-provider: ${{ vars.OIDC_PROVIDER_NAME }}
         oidc-audience: ${{ vars.OIDC_AUDIENCE }}
-        server-tag: ${{ matrix.test == 'code-examples' && '8.8.2.0.0-20260908214755' || needs.get-env-vars.outputs.server-tag }}
+        server-tag: ${{ matrix.test == 'code-examples' && '8.2.0.0-20260908214755' || needs.get-env-vars.outputs.server-tag }}
         server-container-repo: database-docker-virtual/aerospike-server${{ matrix.test == 'ee-code-examples' && '-enterprise' || '' }}
         tools-tag: 13.0.2_1
         config-file: ${{ (matrix.test == 'doctest' || matrix.test == 'ce-code-examples') && './.github/workflows/aerospike-ce.conf' || '' }}

--- a/aerospike_helpers/expressions/string.py
+++ b/aerospike_helpers/expressions/string.py
@@ -18,7 +18,7 @@ String expressions contain expressions for reading and modifying strings.
 
 These expressions mirror the operations from :mod:`String API <aerospike_helpers.operations.string_operations>`.
 
-Requires server version 8.1.3 or later.
+Requires server version 8.2.0 or later.
 
 Unlike operate-level string ops, these macros do not take a ``ctx`` parameter. To target
 a string nested inside a list or map, extract the leaf with

--- a/aerospike_helpers/operations/bitwise_operations.py
+++ b/aerospike_helpers/operations/bitwise_operations.py
@@ -698,7 +698,7 @@ def bit_b64_encode(
     """
     Create bit "b64 encode" operation that returns the base64 text of ``byte_size`` bytes starting from ``byte_offset``.
 
-    Requires server version 8.1.3 or later.
+    Requires server version 8.2.0 or later.
 
     Args:
         bin_name (str): The name of the bin containing the map.

--- a/aerospike_helpers/operations/list_operations.py
+++ b/aerospike_helpers/operations/list_operations.py
@@ -1178,7 +1178,7 @@ def list_join(
     An empty list yields an empty string, and a single-item list yields that item with no separator applied.
     This is the inverse of :py:meth:`~aerospike_helpers.operations.string_operations.split_separator`.
 
-    Requires server version 8.1.3 or later.
+    Requires server version 8.2.0 or later.
 
     Args:
         bin_name (str): The name of the bin containing the list.
@@ -1192,7 +1192,7 @@ def list_join(
         format of the dictionary should be considered an internal detail, and subject to change.
 
     Note:
-        This operation requires server version 8.1.3.0 or greater.
+        This operation requires server version 8.2.0 or greater.
     """
     op_dict = {
         OP_KEY: aerospike._OP_LIST_JOIN,

--- a/aerospike_helpers/operations/string_operations.py
+++ b/aerospike_helpers/operations/string_operations.py
@@ -21,7 +21,7 @@ Index orientation is left-to-right with Unicode codepoint addressing.
 Negative indexes count from the end of the string (-1 is the last
 codepoint). Out-of-bounds indexes are clamped by the server.
 
-String operations require server version 8.1.3 or later. When ctx is not
+String operations require server version 8.2.0 or later. When ctx is not
 :py:obj:`None` and not empty, the operation targets a string nested inside a list or
 map. The ctx-navigated leaf must already be an Aerospike string; operations
 on non-string leaves return :exc:`~aerospike.exception.BinIncompatibleType`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ distance-dirty = "{base_version}+{distance}.{vcs}{rev}.dirty"
 
 [tool.pytest.ini_options]
 filterwarnings = [
-    # These operations are still supported in server < 8.1.3,
+    # These operations are still supported in server < 8.2.0,
     # and these operations are used in many places throughout the test suite.
     "ignore:.*aerospike_helpers\\.operations\\.operations\\.append.*string.*:DeprecationWarning",
     "ignore:.*aerospike_helpers\\.operations\\.operations\\.prepend.*string.*:DeprecationWarning",

--- a/src/main/client/operate.c
+++ b/src/main/client/operate.c
@@ -311,7 +311,7 @@ bool opRequiresKey(int op)
 #define DEPRECATED_APPEND_NAME "aerospike_helpers.operations.operations.append"
 
 #define DEPRECATION_MESSAGE_TEMPLATE                                           \
-    "%s is deprecated for strings in server 8.1.3 or higher."
+    "%s is deprecated for strings in server 8.2.0 or higher."
 
 as_status add_op(AerospikeClient *self, as_error *err,
                  PyObject *py_operation_dict, as_vector *unicodeStrVector,

--- a/test/new_tests/conftest.py
+++ b/test/new_tests/conftest.py
@@ -377,10 +377,10 @@ def expect_earlier_than_server_version_to_fail(as_connection, request):
         # InvalidRequest, BinIncompatibleTypes are exceptions that have been raised
         request.cls.expected_context_for_pos_tests = pytest.raises(e.ServerError)
 
-expect_server_version_earlier_than_8_1_3_to_fail = pytest.mark.parametrize(
+expect_server_version_earlier_than_8_2_0_to_fail = pytest.mark.parametrize(
     "expect_earlier_than_server_version_to_fail",
     [
-        (8, 1, 3)
+        (8, 2, 0)
     ],
     indirect=True
 )

--- a/test/new_tests/test_bitwise_operations.py
+++ b/test/new_tests/test_bitwise_operations.py
@@ -3,7 +3,7 @@ import pytest
 import random
 from aerospike import exception as e
 from aerospike_helpers.operations import bitwise_operations
-from .conftest import expect_server_version_earlier_than_8_1_3_to_fail
+from .conftest import expect_server_version_earlier_than_8_2_0_to_fail
 
 import aerospike
 from contextlib import nullcontext
@@ -1667,7 +1667,7 @@ class TestBitwiseOperations(object):
             ),
         ]
     )
-    @expect_server_version_earlier_than_8_1_3_to_fail
+    @expect_server_version_earlier_than_8_2_0_to_fail
     @pytest.mark.usefixtures("expect_earlier_than_server_version_to_fail")
     def test_bit_b64_encode(self, kwargs, expected):
         ops = [

--- a/test/new_tests/test_client_config_level_options.py
+++ b/test/new_tests/test_client_config_level_options.py
@@ -246,8 +246,8 @@ POLICY_WITH_FILTER_RETURNING_FALSE = {"expressions": exp.Eq(exp.IntBin(BIN_NAME)
 
 
 def skip_if_exp_trace_unsupported():
-    if (TestBaseClass.major_ver, TestBaseClass.minor_ver, TestBaseClass.patch_ver) < (8, 1, 3):
-        pytest.skip("Expression tracing only supported in server 8.1.3 or higher")
+    if (TestBaseClass.major_ver, TestBaseClass.minor_ver, TestBaseClass.patch_ver) < (8, 2, 0):
+        pytest.skip("Expression tracing only supported in server 8.2.0 or higher")
 
 
 def assert_batch_record_filtered_out_with_exp_trace(batch_records):

--- a/test/new_tests/test_exception_subcode.py
+++ b/test/new_tests/test_exception_subcode.py
@@ -108,7 +108,7 @@ class TestExceptionSubcode:
             or
             # If running against a unsupported version, we expect subcode to always return 0
             # (and no undefined behavior)
-            (TestBaseClass.major_ver, TestBaseClass.minor_ver, TestBaseClass.patch_ver) < (8, 1, 3)
+            (TestBaseClass.major_ver, TestBaseClass.minor_ver, TestBaseClass.patch_ver) < (8, 2, 0)
         )
         if subcode_should_be_zero:
             assert excinfo.value.subcode == 0
@@ -149,7 +149,7 @@ class TestExceptionSubcode:
         self.as_connection.batch_write(brs, policy_batch={ERROR_DETAIL_VERBOSITY_SETTING: aerospike.ERROR_DETAIL_MESSAGE})
         for br in brs.batch_records:
             assert isinstance(br.message, str)
-            if (TestBaseClass.major_ver, TestBaseClass.minor_ver, TestBaseClass.patch_ver) < (8, 1, 3):
+            if (TestBaseClass.major_ver, TestBaseClass.minor_ver, TestBaseClass.patch_ver) < (8, 2, 0):
                 assert br.subcode == 0
             else:
                 assert br.subcode > 0
@@ -168,7 +168,7 @@ class TestExceptionSubcode:
 
         for br in brs.batch_records:
             assert isinstance(br.message, str)
-            if (TestBaseClass.major_ver, TestBaseClass.minor_ver, TestBaseClass.patch_ver) < (8, 1, 3):
+            if (TestBaseClass.major_ver, TestBaseClass.minor_ver, TestBaseClass.patch_ver) < (8, 2, 0):
                 assert br.subcode == 0
             else:
                 assert br.subcode > 0
@@ -183,8 +183,8 @@ class TestExceptionSubcode:
         ]
     )
     def test_error_detail_exp_trace(self, verbosity_level):
-        if (TestBaseClass.major_ver, TestBaseClass.minor_ver, TestBaseClass.patch_ver) < (8, 1, 3):
-            pytest.skip("Expression tracing only supported in server 8.1.3 or higher")
+        if (TestBaseClass.major_ver, TestBaseClass.minor_ver, TestBaseClass.patch_ver) < (8, 2, 0):
+            pytest.skip("Expression tracing only supported in server 8.2.0 or higher")
 
         policy = {
             ERROR_DETAIL_VERBOSITY_SETTING: verbosity_level,
@@ -211,8 +211,8 @@ class TestExceptionSubcode:
     )
     @pytest.mark.usefixtures("setup")
     def test_dyn_config(self, api_method, kwargs):
-        if (TestBaseClass.major_ver, TestBaseClass.minor_ver, TestBaseClass.patch_ver) < (8, 1, 3):
-            pytest.skip("Expression tracing only supported in server 8.1.3 or higher")
+        if (TestBaseClass.major_ver, TestBaseClass.minor_ver, TestBaseClass.patch_ver) < (8, 2, 0):
+            pytest.skip("Expression tracing only supported in server 8.2.0 or higher")
 
         config = TestBaseClass.get_connection_config()
         provider = aerospike.ConfigProvider(DYN_CONFIG_PATH)

--- a/test/new_tests/test_expressions_bit.py
+++ b/test/new_tests/test_expressions_bit.py
@@ -25,7 +25,7 @@ from aerospike_helpers.expressions import (
     Eq,
 )
 from aerospike_helpers.operations import expression_operations as expr_ops
-from .conftest import expect_server_version_earlier_than_8_1_3_to_fail
+from .conftest import expect_server_version_earlier_than_8_2_0_to_fail
 
 import aerospike
 from . import as_errors
@@ -358,7 +358,7 @@ class TestExpressions(TestBaseClass):
             (0, None, False, base64.b64encode(BASE64_BYTES).decode("utf-8"))
         ]
     )
-    @expect_server_version_earlier_than_8_1_3_to_fail
+    @expect_server_version_earlier_than_8_2_0_to_fail
     @pytest.mark.usefixtures("expect_earlier_than_server_version_to_fail")
     def test_bit_b64_encode(self, byte_offset, byte_size, invert_size, expected):
         bin = "base64_bytes"

--- a/test/new_tests/test_expressions_list.py
+++ b/test/new_tests/test_expressions_list.py
@@ -43,7 +43,7 @@ from aerospike_helpers.expressions import (
     ResultType,
     Val
 )
-from .conftest import expect_server_version_earlier_than_8_1_3_to_fail
+from .conftest import expect_server_version_earlier_than_8_2_0_to_fail
 
 import aerospike
 from . import as_errors
@@ -958,7 +958,7 @@ class TestExpressions(TestBaseClass):
             ("list_of_one_str", "b"),
         ]
     )
-    @expect_server_version_earlier_than_8_1_3_to_fail
+    @expect_server_version_earlier_than_8_2_0_to_fail
     @pytest.mark.usefixtures("expect_earlier_than_server_version_to_fail")
     def test_list_join(self, bin_name, expected):
         expr = ListJoin(None, None, bin_name).compile()

--- a/test/new_tests/test_expressions_string.py
+++ b/test/new_tests/test_expressions_string.py
@@ -9,7 +9,7 @@ from aerospike import exception as e
 
 from .test_base_class import TestBaseClass
 from .string_helpers import *
-from .conftest import expect_server_version_earlier_than_8_1_3_to_fail, TEST_NS, TEST_SET
+from .conftest import expect_server_version_earlier_than_8_2_0_to_fail, TEST_NS, TEST_SET
 KEY = (TEST_NS, TEST_SET, 1)
 
 
@@ -87,7 +87,7 @@ class TestExpressions:
             ),
         ]
     )
-    @expect_server_version_earlier_than_8_1_3_to_fail
+    @expect_server_version_earlier_than_8_2_0_to_fail
     def test_reading_str_bins(self, expr, expected_result):
         compiled_expr = expr.compile()
         ops = [
@@ -262,7 +262,7 @@ class TestExpressions:
         ]
     )
     @kwargs_policy
-    @expect_server_version_earlier_than_8_1_3_to_fail
+    @expect_server_version_earlier_than_8_2_0_to_fail
     def test_expression_write(self, kwargs_policy: dict, expr, expr_kwargs: dict, expected_result):
         compiled_expr = expr(**expr_kwargs, **kwargs_policy).compile()
         ops = [

--- a/test/new_tests/test_get_put.py
+++ b/test/new_tests/test_get_put.py
@@ -727,7 +727,7 @@ class TestGetPut:
             self.as_connection.put(key, rec, meta, policy)
         assert excinfo.value.code == 3
 
-        if (TestBaseClass.major_ver, TestBaseClass.minor_ver, TestBaseClass.patch_ver) < (8, 1, 3):
+        if (TestBaseClass.major_ver, TestBaseClass.minor_ver, TestBaseClass.patch_ver) < (8, 2, 0):
             assert "AEROSPIKE_ERR_RECORD_GENERATION" in excinfo.value.msg
 
         (key, meta, bins) = self.as_connection.get(key)

--- a/test/new_tests/test_new_list_operation_helpers.py
+++ b/test/new_tests/test_new_list_operation_helpers.py
@@ -2,7 +2,7 @@
 import pytest
 from aerospike import exception as e
 from aerospike_helpers.operations import list_operations
-from .conftest import expect_server_version_earlier_than_8_1_3_to_fail
+from .conftest import expect_server_version_earlier_than_8_2_0_to_fail
 
 import aerospike
 
@@ -494,7 +494,7 @@ class TestNewListOperationsHelpers(object):
             ("list_of_one_str", None, "a")
         ]
     )
-    @expect_server_version_earlier_than_8_1_3_to_fail
+    @expect_server_version_earlier_than_8_2_0_to_fail
     @pytest.mark.usefixtures("expect_earlier_than_server_version_to_fail")
     def test_list_join(self, bin_name: str, separator: str | None, expected: str):
         ops = [

--- a/test/new_tests/test_string_operations.py
+++ b/test/new_tests/test_string_operations.py
@@ -8,12 +8,12 @@ from aerospike import exception as e
 from aerospike_helpers import cdt_ctx
 from contextlib import nullcontext
 
-from .conftest import expect_server_version_earlier_than_8_1_3_to_fail, TEST_NS, TEST_SET, TestBaseClass
+from .conftest import expect_server_version_earlier_than_8_2_0_to_fail, TEST_NS, TEST_SET, TestBaseClass
 from .string_helpers import *
 KEY = (TEST_NS, TEST_SET, 1)
 
 
-@expect_server_version_earlier_than_8_1_3_to_fail
+@expect_server_version_earlier_than_8_2_0_to_fail
 class TestStringOperations:
     @pytest.fixture(autouse=True)
     def setup(self, request, as_connection, expect_earlier_than_server_version_to_fail):
@@ -457,7 +457,7 @@ class TestStringOperations:
             str_ops.insert(bin_name=STR_BIN_NAME, index=0, value="a", policy=policy)
         ]
 
-        if (TestBaseClass.major_ver, TestBaseClass.minor_ver, TestBaseClass.patch_ver) < (8, 1, 3):
+        if (TestBaseClass.major_ver, TestBaseClass.minor_ver, TestBaseClass.patch_ver) < (8, 2, 0):
             expected_exc = e.InvalidRequest
         else:
             expected_exc = e.BinExistsError
@@ -471,7 +471,7 @@ class TestStringOperations:
             str_ops.insert(bin_name="aaaa", index=0, value="a", policy=policy)
         ]
 
-        if (TestBaseClass.major_ver, TestBaseClass.minor_ver, TestBaseClass.patch_ver) < (8, 1, 3):
+        if (TestBaseClass.major_ver, TestBaseClass.minor_ver, TestBaseClass.patch_ver) < (8, 2, 0):
             expected_context = pytest.raises(e.InvalidRequest)
         else:
             expected_context = nullcontext()

--- a/test/new_tests/test_string_operations.py
+++ b/test/new_tests/test_string_operations.py
@@ -566,7 +566,6 @@ class TestStringOperations:
             (str_ops.contains, True)
         ]
     )
-    @pytest.mark.xfail(reason="This currently fails on server 8.1.3 RC3. This should pass on RC4, and we can tell if the result is XPASS")
     def test_read_across_normalization_forms(self, op, expected_result, bin_substr, str_param):
         BIN_NAME = "str"
         self.as_connection.put(KEY, bins={BIN_NAME: bin_substr})


### PR DESCRIPTION
## Extra changes

test: unmark test_read_across_normalization_forms as "expected to fail" since test now passes on the latest server 8.2 RC