### PR TITLE
[CLIENT-4646]: replace xfail with explicit InvalidRequest assertion for InList bin-reference in path filter

### DIFF
--- a/test/new_tests/test_path_expressions.py
+++ b/test/new_tests/test_path_expressions.py
@@ -845,15 +845,6 @@ class TestPathExprOperations:
                 # Only the third list element is in [3]
                 [3]
             ),
-            pytest.param(
-                InList(
-                    LoopVarInt(aerospike.EXP_LOOPVAR_VALUE),
-                    SECOND_LIST_OF_INTS_BIN_NAME
-                ),
-                # Only the third list element is in SECOND_LIST_OF_INTS_BIN_NAME
-                [3],
-                marks=pytest.mark.xfail(reason="Known bug where server 8.1.2 raises InvalidRequest")
-            ),
         ]
     )
     @expect_server_version_earlier_than_8_1_2_to_fail
@@ -868,6 +859,26 @@ class TestPathExprOperations:
         with self.expected_context_for_pos_tests:
             _, _, bins = self.as_connection.operate(self.key, ops)
             assert bins[self.LIST_OF_INTS_BIN_NAME] == expected_results
+
+    def test_expr_in_list_referencing_bin(self):
+        # A path-expression filter is evaluated per-element with no access to the record, so
+        # referencing another bin from inside the filter can never resolve. This is not a bug;
+        # the server correctly rejects it with InvalidRequest.
+        if (TestBaseClass.major_ver, TestBaseClass.minor_ver, TestBaseClass.patch_ver) < (8, 1, 2):
+            pytest.skip("Server versions < 8.1.2 will not return an invalid request error."
+                        "We consider this undefined behavior")
+        filter_expr = InList(
+            LoopVarInt(aerospike.EXP_LOOPVAR_VALUE),
+            self.SECOND_LIST_OF_INTS_BIN_NAME
+        ).compile()
+        ctx = [
+            cdt_ctx.cdt_ctx_all_children_with_filter(filter_expr)
+        ]
+        ops = [
+            operations.select_by_path(self.LIST_OF_INTS_BIN_NAME, ctx, aerospike.EXP_PATH_SELECT_LIST_VALUE)
+        ]
+        with pytest.raises(e.InvalidRequest):
+            self.as_connection.operate(self.key, ops)
 
     def test_expr_in_map_instead_of_list(self):
         filter_expr = InList(LoopVarInt(aerospike.EXP_LOOPVAR_VALUE), self.MAP_BIN_NAME).compile()


### PR DESCRIPTION
Fixes: https://aerospike.atlassian.net/browse/CLIENT-4646

**Description:** 
Converts the test_expr_in_list xfail case into a dedicated test (test_expr_in_list_referencing_bin) that asserts InvalidRequest — confirmed server behavior per CLIENT-4646 investigation, not a client bug.      